### PR TITLE
Optimize viewport for mobile

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Overlay Fact Sheet</title>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NGCH8KPZG9"></script>


### PR DESCRIPTION
Read more at https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag

Before change: visiting the site on mobile results in tiny text.
After change: visiting the site on mobile correctly sizes the viewport to the display width, text is readable