### PR TITLE
Use grid for quotes, add landmark regions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,583 +28,592 @@
 </head>
 
 <body>
-<div class="header text-align-center">
+<header class="header text-align-center">
   <svg aria-hidden="true" class="logo" height="120" width="120" viewBox="0 0 120 120"
-       xmlns="http://www.w3.org/2000/svg">
+    xmlns="http://www.w3.org/2000/svg">
     <path
       d="M60 0c33.137 0 60 26.863 60 60s-26.863 60-60 60S0 93.137 0 60 26.863 0 60 0zm4.167 26.667h-25c-6.904 0-12.5 5.596-12.5 12.5v25c0 6.903 5.596 12.5 12.5 12.5h4.166v4.166c0 6.904 5.597 12.5 12.5 12.5h25c6.904 0 12.5-5.596 12.5-12.5v-25c0-6.903-5.596-12.5-12.5-12.5h-4.166v-4.166c0-6.904-5.597-12.5-12.5-12.5zM80.833 47.5a8.343 8.343 0 018.334 8.333v25a8.343 8.343 0 01-8.334 8.334h-25a8.343 8.343 0 01-8.333-8.334v-4.166h16.667c6.903 0 12.5-5.597 12.5-12.5V47.5h4.166zM64.167 30.833a8.343 8.343 0 018.333 8.334v4.166H55.833c-6.903 0-12.5 5.597-12.5 12.5V72.5h-4.166a8.343 8.343 0 01-8.334-8.333v-25a8.343 8.343 0 018.334-8.334h25z"
       fill-rule="evenodd"/>
   </svg>
   <h1 class="title">Overlay Fact Sheet</h1>
-</div>
+</header>
 
-<div class="container">
-  <h2 id="introduction-definition-and-history-of-web-accessibility-overlays">
-    Introduction, definition, and history of web accessibility overlays
-  </h2>
-  <p class="summary">
-    Overlays are a broad term for technologies aimed at improving the
-    accessibility of a website by applying third-party source code (typically
-    JavaScript) to make improvements to the front-end code of the website.
-  </p>
-  <p>Website add-on products purporting to improve accessibility go back to the
-    late 1990s with products like <a href="https://en.wikipedia.org/wiki/Hoya_Corporation#ReadSpeaker">Readspeaker</a>
-    and <a href="https://en.wikipedia.org/wiki/BrowseAloud">Browsealoud</a>. Both
-    of which added text-to-speech capabilities to the website(s) on which they
-    were installed.</p>
-  <p>Later, similar products came to market that added additional tools to
-    their software that allow user-based control of things like font-sizes and
-    changes to the web pages colors so that contrast is improved. Products like
-    Userway, EqualWeb, AudioEye, User1st, MaxAccess, and accessiBe fall into this category. 
-    These products are sometimes also white labelled under additional names.</p>
-
-  <h2 id="strengths-and-weaknesses-of-overlay-widgets">
-    Strengths and weaknesses of overlay “widgets”
-  </h2>
-  <p class="summary">
-    Overlay widgets are unnecessary and are poorly placed in the
-    technology stack.
-  </p>
-  <p>As stated above, some overlay products contain widgets which present a
-    series of controls that modify the presentation of the page they're on.
-    Depending on the product, those changes may do things like change the page
-    contrast, enlarge the size of the page's text, or perform other changes to
-    the page that are intended to improve the experience for users with
-    disabilities.</p>
-  <p>To laypersons, these features may seem beneficial, but their practical
-    value is largely overstated because the end users that these features claim
-    to serve will already have the necessary features on their computer, either
-    as a built-in feature or as an additional piece of software that the user
-    needs to access not only the Web but all software.</p>
-  <p>On this latter point, it is a mistake to believe that the features
-    provided by the overlay widget will be of much use by end users because if
-    those features were <strong>necessary</strong> to use the website, they'd be
-    needed for all websites that the user interacts with. Instead, the widget is 
-    as—at best—redundant functionality with what the user already has.</p>
-
-  <h2 id="strengths-and-weaknesses-of-automated-repair">
-    Strengths and weaknesses of automated repair
-  </h2>
-  <p class="summary">
-    While some automated repair is possible, customers should be
-    discouraged from using an overlay as a long-term solution.
-  </p>
-  <p>Some overlay products have capabilities aimed at providing accessibility
-    repairs to the underlying page on which the overlay is added. These repairs
-    are applied when the page loads in the user's browser.</p>
-  <p>While it is true that a non-trivial array of accessibility problems can be
-    repaired in this manner, the nature, extent, and accuracy of such repair are
-    limited by a number of important factors:</p>
-  <ul>
-    <li>Automated application of text alternatives for images is not
-      reliable
-    </li>
-    <li>Automated repair of field labels, error management, error handling, and
-      focus control on forms is not reliable
-    </li>
-    <li>Automated repair of keyboard access is not reliable</li>
-    <li>Modern, component-based user interfaces, such as those using ReactJS,
-      Angular, or Vue may change the state of all or some of the underlying page
-      independently of the overlay, rendering it unable to fix those
-      JavaScript-driven changes to content.
-    </li>
-    <li>Repairs to the page can either slow down page load times or cause
-      unexpected page changes for assistive technology users.
-    </li>
-  </ul>
-
-  <p>In addition to the above, overlays do not repair content in Flash, Java,
-    Silverlight, PDF, HTML5 Canvas, SVG, or media files.</p>
-  <p>An additional class of product exists, which only perform automated
-    repairs and are marketed as a temporary solution. These include Amaze by
-    Deque Systems, Alchemy by Level Access, and Sentinel by Tenon.
-  <p>For purposes of this document, these products aren't considered to be in
-    the same class of product as the overlays that provide widgets. The most
-    notable difference, beyond the lack of a “widget” is that Amaze,
-    Alchemy, and Sentinel are understood by their manufacturers as being intended
-    for use as an <strong>interim</strong> solution.</p>
-
-  <h2 id="fitness-for-achieving-compliance-with-accessibility-standards">
-    Fitness for achieving compliance with accessibility standards
-  </h2>
-  <p class="summary">While the use of an overlay may improve
-    compliance with a handful of provisions in major accessibility standards,
-    full compliance cannot be achieved with an overlay.</p>
-  <p>Among the many claims made by overlay vendors is the claim that the use of
-    their product will being the site into compliance with accessibility
-    standards such as WCAG 2.x, related and derivative standards, and laws that
-    mandate compliance with those standards.</p>
-
-  <blockquote class="conformance-quote">
-    Conformance to a standard means that you meet or satisfy the
-    ‘requirements’ of the standard. In WCAG 2.0 the
-    ‘requirements’ are the Success Criteria. To conform to WCAG 2.0, you need
-    to satisfy the Success Criteria, that is, there is no content which
-    violates the Success Criteria.
-    <cite>
-      <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding
-        WCAG 2.0: Understanding Conformance</a>
-    </cite>
-  </blockquote>
-
-  <p>Given that conformance is defined as meeting <strong>all</strong>
-    requirements of the standard, these products' documented inability to repair
-    all possible issues means that they cannot bring a website into compliance.
-    Products marketed with such claims should be viewed with significant
-    scepticism.</p>
-</div>
-
-<div class="in-their-own-words">
+<main>
   <div class="container">
-    <h2 id="in-their-own-words">In their own words</h2>
+    <h2 id="introduction-definition-and-history-of-web-accessibility-overlays">
+      Introduction, definition, and history of web accessibility overlays
+    </h2>
     <p class="summary">
-      Many users with disabilities have expressed strong words of
-      dissatisfaction with overlay products. As shown below, overlays
-      themselves may have accessibility problems significant enough for users
-      to take steps to actively block overlays from appearing at all.
+      Overlays are a broad term for technologies aimed at improving the
+      accessibility of a website by applying third-party source code (typically
+      JavaScript) to make improvements to the front-end code of the website.
     </p>
-    <p>Please note: while this section may mention specific vendors, these
-      comments are par-for-the-course when it comes to the user experience
-      provided by overlay widgets which have, in themselves, a pattern of
-      negatively impacting the user experience.</p>
+    <p>Website add-on products purporting to improve accessibility go back to the
+      late 1990s with products like <a href="https://en.wikipedia.org/wiki/Hoya_Corporation#ReadSpeaker">Readspeaker</a>
+      and <a href="https://en.wikipedia.org/wiki/BrowseAloud">Browsealoud</a>. Both
+      of which added text-to-speech capabilities to the website(s) on which they
+      were installed.</p>
+    <p>Later, similar products came to market that added additional tools to
+      their software that allow user-based control of things like font-sizes and
+      changes to the web pages colors so that contrast is improved. Products like
+      Userway, EqualWeb, AudioEye, User1st, MaxAccess, and accessiBe fall into this category.
+      These products are sometimes also white labelled under additional names.</p>
 
-    <blockquote id="derekriemer" class="quote">
-      …assuming your tool can do a good job making something accessible, it can
-      do an even better job making something accessible running directly on the
-      user's machine having access to machine code and machine APIs
+    <h2 id="strengths-and-weaknesses-of-overlay-widgets">
+      Strengths and weaknesses of overlay “widgets”
+    </h2>
+    <p class="summary">
+      Overlay widgets are unnecessary and are poorly placed in the
+      technology stack.
+    </p>
+    <p>As stated above, some overlay products contain widgets which present a
+      series of controls that modify the presentation of the page they're on.
+      Depending on the product, those changes may do things like change the page
+      contrast, enlarge the size of the page's text, or perform other changes to
+      the page that are intended to improve the experience for users with
+      disabilities.</p>
+    <p>To laypersons, these features may seem beneficial, but their practical
+      value is largely overstated because the end users that these features claim
+      to serve will already have the necessary features on their computer, either
+      as a built-in feature or as an additional piece of software that the user
+      needs to access not only the Web but all software.</p>
+    <p>On this latter point, it is a mistake to believe that the features
+      provided by the overlay widget will be of much use by end users because if
+      those features were <strong>necessary</strong> to use the website, they'd be
+      needed for all websites that the user interacts with. Instead, the widget is 
+      as—at best—redundant functionality with what the user already has.</p>
+
+    <h2 id="strengths-and-weaknesses-of-automated-repair">
+      Strengths and weaknesses of automated repair
+    </h2>
+    <p class="summary">
+      While some automated repair is possible, customers should be
+      discouraged from using an overlay as a long-term solution.
+    </p>
+    <p>Some overlay products have capabilities aimed at providing accessibility
+      repairs to the underlying page on which the overlay is added. These repairs
+      are applied when the page loads in the user's browser.</p>
+    <p>While it is true that a non-trivial array of accessibility problems can be
+      repaired in this manner, the nature, extent, and accuracy of such repair are
+      limited by a number of important factors:</p>
+    <ul>
+      <li>Automated application of text alternatives for images is not
+        reliable
+      </li>
+      <li>Automated repair of field labels, error management, error handling, and
+        focus control on forms is not reliable
+      </li>
+      <li>Automated repair of keyboard access is not reliable</li>
+      <li>Modern, component-based user interfaces, such as those using ReactJS,
+        Angular, or Vue may change the state of all or some of the underlying page
+        independently of the overlay, rendering it unable to fix those
+        JavaScript-driven changes to content.
+      </li>
+      <li>Repairs to the page can either slow down page load times or cause
+        unexpected page changes for assistive technology users.
+      </li>
+    </ul>
+
+    <p>In addition to the above, overlays do not repair content in Flash, Java,
+      Silverlight, PDF, HTML5 Canvas, SVG, or media files.</p>
+    <p>An additional class of product exists, which only perform automated
+      repairs and are marketed as a temporary solution. These include Amaze by
+      Deque Systems, Alchemy by Level Access, and Sentinel by Tenon.
+    <p>For purposes of this document, these products aren't considered to be in
+      the same class of product as the overlays that provide widgets. The most
+      notable difference, beyond the lack of a “widget” is that Amaze,
+      Alchemy, and Sentinel are understood by their manufacturers as being intended
+      for use as an <strong>interim</strong> solution.</p>
+
+    <h2 id="fitness-for-achieving-compliance-with-accessibility-standards">
+      Fitness for achieving compliance with accessibility standards
+    </h2>
+    <p class="summary">While the use of an overlay may improve
+      compliance with a handful of provisions in major accessibility standards,
+      full compliance cannot be achieved with an overlay.</p>
+    <p>Among the many claims made by overlay vendors is the claim that the use of
+      their product will being the site into compliance with accessibility
+      standards such as WCAG 2.x, related and derivative standards, and laws that
+      mandate compliance with those standards.</p>
+
+    <blockquote class="conformance-quote">
+      Conformance to a standard means that you meet or satisfy the
+      ‘requirements’ of the standard. In WCAG 2.0 the
+      ‘requirements’ are the Success Criteria. To conform to WCAG 2.0, you need
+      to satisfy the Success Criteria, that is, there is no content which
+      violates the Success Criteria.
       <cite>
-        <a class="quote-source" href="https://twitter.com/DerekRiemer/status/1365136025861775364">DerekRiemer</a>
+        <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance">Understanding
+          WCAG 2.0: Understanding Conformance</a>
       </cite>
     </blockquote>
 
-    <blockquote id="wilfsplodnokit" class="quote">
-      …I finally managed to gain access to my @NameCheap account by blocking
-      #AccessiBe in my Windows Hosts file. I should not need to do this to use
-      the Internet. AccessiBe needs to AccessiBeGone
-      <cite>
-        <a class="quote-source" href="https://twitter.com/WilfSplodNokit/status/1365478393895153664">WilfSplodNokit</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="geauxender" class="quote">
-      …I know with 100% certainty, any site which has deployed an overlay in
-      the past year and a half has been less useable for both my wife and
-      me—both blind.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/GeauxEnder/status/1364943889132646408">GeauxEnder</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="big_d01" class="quote">
-      …Still a pain to even try reading the article on a mobile device
-      because of the constant interruption every few seconds. Considering
-      every site using your service also has this problem… Nope.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/Big_D01/status/1365187231829254144">Big_D01</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="w9fyi" class="quote">
-      …Making a webpage accessible does take work, and simply telling a
-      business they can install your plugin is absolutely foolish, you build,
-      and design accessibility in to a webpage using WCAG standards.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/w9fyi/status/1366019424415866880">w9fyi</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="kevmarmol_ct" class="quote">
-      …Suggesting one line of code is cheap so you should do it by inference
-      suggests disabled lives aren't worth investing in either. #a11y
-      <cite>
-        <a class="quote-source" href="https://twitter.com/Kevmarmol_CT/status/1365005141594750986">Kevmarmol_CT</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="eluberoff" class="quote">
-      @AccessiBe Just to demonstrate my good faith, here's a quick free audit
-      of https://t.co/1mQGCCtnIs. You capture &quot;tab&quot; which is the
-      standard way to navigate. There's no way to not enable your overlay if
-      I want to navigate the page. Once the overlay is enabled, wild things
-      happen.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/eluberoff/status/1366386598770839557">eluberoff</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="turtlecatpurrz" class="quote">
-      #AccessiBe makes sites harder to use by getting in the way of browsing
-      and changing access barriers on a page, not fixing them. A student and I
-      came across an &quot;enhanced&quot; website and to my shame, we left
-      because navigating that mess was beyond my skills, on that day.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/turtlecatpurrz/status/1365099776207851523">turtlecatpurrz</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="singingtigress" class="quote">
-      Accessibility overlays are not the answer, and AccessiBe is no exception.
-      As a screen reader user, numerous sites have become less usable for me
-      with this overlay. Discrediting reputable accessiblity professionals and
-      advocates will not sway me on this view. https://t.co/ZgFt8JtsbZ
-      <cite>
-        <a class="quote-source" href="https://twitter.com/SingingTigress/status/1364922970670583815">SingingTigress</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="marcozehe" class="quote" lang="de">
-      An die Screen Reader nutzenden Follower: Vielleicht habt ihr schon von
-      #Accessibe gehört, einem Overlay, das behauptet, Seiten, in denen es
-      eingebunden ist, zugänglicher zu machen. Ich möchte nicht näher ins
-      Detail gehen. Kurz gesagt: Kompletter Blödsinn. Finger weg!
-      <cite>
-        <a class="quote-source" href="https://twitter.com/MarcoZehe/status/1365587195596181507">MarcoZehe</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="twithoff" class="quote">
-      Automated solutions which promise to make your site accessible can't. It
-      takes more than automation to achieve this requirement. You won't be safe
-      from liability. you will almost assuredly negatively impact your
-      customers with disabilities.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/twithoff/status/1364957890050686976">twithoff</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="borrisinabox" class="quote">
-      Every time I go on a website and I hear the #accessiBe notification that
-      this site is adjusted to my screen reader, I know that my blocker isn't
-      working properly, and I'm in for a hellish experience on that particular website.
-      https://t.co/ZFzKMfUe0t
-      <cite>
-        <a class="quote-source" href="https://twitter.com/BorrisInABox/status/1364295702696890370">BorrisInABox</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="racheleditullio" class="quote">
-      I tried using this @AccessiBe site with VoiceOver in Chrome on iOS.
-      The 4-star rating is announced as &quot;unpronounceable&quot;
-      🤦‍♀️ https://t.co/f4MxQ2eLLP"
-      <cite>
-        <a class="quote-source"
-           href="https://twitter.com/racheleditullio/status/1365739183839588357">racheleditullio</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="kit_flowerstorm" class="quote">
-      I wrote an email to their customer service detailing that I can not use
-      their site due to the overlay, but… I really am disappointed, but I hope
-      they listen. @Goodfair_ - please stop using AccessiBe.
-      <cite>
-        <a class="quote-source"
-           href="https://twitter.com/kit_flowerstorm/status/1364605580405575681">kit_flowerstorm</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="atfarnum" class="quote">
-      I'm not an accessibility expert, just a screen reader user with decent
-      skills telling you that this thread is spot on and my experience with
-      #AccessiBe is that it makes sites with accessibility issues even harder
-      to work around. https://t.co/cfyrEqXwTy
-      <cite>
-        <a class="quote-source" href="https://twitter.com/atfarnum/status/1365075850861887490">atfarnum</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="smartudlab" class="quote">
-      …If you are blind or low vision and rely on assistive technologies like
-      screen readers, you may have begun finding popular websites becoming less
-      usable… this page describes how to ban AccessiBe from ever reaching your
-      computer… https://t.co/qbiKvolizS
-      <cite>
-        <a class="quote-source" href="https://twitter.com/smartudlab/status/1365651400638615559">smartudlab</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="kellylford" class="quote">
-      OK, this seems very wrong to me. A local chain here named Fleet Farm is
-      now using AccessiBe. It makes a mess of the search for location feature.
-      This is what I now get on the start of the result page.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/kellylford/status/1363698942152757253">kellylford</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="mhorspool" class="quote">
-      Thank goodness Firefox blocks their accessibility detection. For me,
-      focus jumps all over the place with #AccessiBe enabled. When it's
-      disabled, it behaves itself.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/mhorspool/status/1364983194546757634">mhorspool</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="cswordpress" class="quote">
-      There are 0 automated tools that can tetect accessibility problems
-      accurately at anything above 30% of the time. 0. This is commonly known
-      by anyone who's been in this space for at least a week. #AccessiBe
-      <cite>
-        <a class="quote-source" href="https://twitter.com/cswordpress/status/1365042078401576968">cswordpress</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="wtbdavidg" class="quote">
-      There's a perfectly practical tool for making websites accessible. It's
-      called a programmer. The needs that matter in making a website accessible
-      are those of the users. If you can't meet those, then you can't meet the
-      basic costs of doing business.
-      <cite>
-        <a class="quote-source" href="https://twitter.com/WTBDavidG/status/1366074519086055425">WTBDavidG</a>
-      </cite>
-    </blockquote>
-
-    <blockquote id="catchthesewords" class="quote">
-      When #AccessiBe is enabled, the page is flooded with headings. Lots of
-      heading level 2's. The title of each phone remains a heading in both
-      versions of the page, but with it enabled, things like cost, display, and
-      all the other components of the tables become headings as well.
-      <cite>
-        <a class="quote-source"
-           href="https://twitter.com/CatchTheseWords/status/1364915942157922308">CatchTheseWords</a>
-      </cite>
-    </blockquote>
+    <p>Given that conformance is defined as meeting <strong>all</strong>
+      requirements of the standard, these products' documented inability to repair
+      all possible issues means that they cannot bring a website into compliance.
+      Products marketed with such claims should be viewed with significant
+      scepticism.</p>
   </div>
-</div>
 
-<div class="container">
-  <h2 id="conclusion">
-    Conclusion
-  </h2>
-  <p class="summary">
-    No overlay product on the market can cause a website to become fully
-    compliant with any existing accessibility standard and therefore cannot
-    eliminate legal risk.
-  </p>
-  <p>Accessibility on the Web is a big challenge, both for owners of websites
-    and for the users of those websites. The invention of novel approaches to
-    resolving this challenge is to be commended.</p>
-  <p>However, in the case of overlays—especially those which attempt to add
-    widgets that present assistive features—the challenge is not being met. Even
-    more problematic are the deceptive marketing provided by some overlay
-    vendors who promise that implementing their product will give their
-    customer's sites immediate compliance with laws and standards.</p>
+  <div class="in-their-own-words">
+    <div class="container">
+      <h2 id="in-their-own-words">In their own words</h2>
+      <p class="summary">
+        Many users with disabilities have expressed strong words of
+        dissatisfaction with overlay products. As shown below, overlays
+        themselves may have accessibility problems significant enough for users
+        to take steps to actively block overlays from appearing at all.
+      </p>
+      <p>Please note: while this section may mention specific vendors, these
+        comments are par-for-the-course when it comes to the user experience
+        provided by overlay widgets which have, in themselves, a pattern of
+        negatively impacting the user experience.</p>
+      </div>
 
-  <h2 id="statement-from-sponsors-and-signatories-to-this-fact-sheet">
-    Statement from sponsors and signatories to this fact sheet
-  </h2>
-  <p>As a result of the above information:</p>
-  <ol>
-    <li>We will never advocate, recommend, or integrate an overlay which
-      deceptively markets itself as providing automated compliance with laws
-      or standards.
-    </li>
-    <li>We will always advocate for the remediation of accessibility issues at
-      the source of the original error.
-    </li>
-    <li>We will refuse to stay silent when overlay vendors use deception to
-      market their products.
-    </li>
-    <li>More specifically, we hereby advocate for the removal of accessiBe,
-      AudioEye, UserWay, User1st, MK-Sense, MaxAccess, and all similar products and
-      encourage the site owners who've implemented these products to use more
-      robust, independent, and permanent strategies to making their sites
-      more accessible.
-    </li>
-  </ol>
-</div>
+      <div class="quotes">
+        <blockquote id="derekriemer" class="quote">
+          …assuming your tool can do a good job making something accessible, it can
+          do an even better job making something accessible running directly on the
+          user's machine having access to machine code and machine APIs
+          <cite>
+            <a class="quote-source" href="https://twitter.com/DerekRiemer/status/1365136025861775364">DerekRiemer</a>
+          </cite>
+        </blockquote>
 
-<div class="container">
-  <h3>Signed by:</h3>
-  <!--//
-    Add your name to this list in accordance with the guidance provided in the repository's README document
-  //-->
-  <ol>
-    <li>Karl Groves, Founder and President, Tenon.io</li>
-    <li>Nicolas Steenhout, Independent accessibility consultant</li>
-    <li>Rian Rietveld, web accessibility specialist, Level Level</li>
-    <li>Weston Thayer, Founder, Assistiv Labs</li>
-    <li>Denis Boudreau, Accessibility consultant</li>
-    <li>Meryl K. Evans, accessibility advocate</li>
-    <li>Makoto Ueki, Web accessibility consultant, Infoaxia</li>
-    <li>Michael Spellacy, Accessibility Consultant</li>
-    <li>Helen Burge, Accessibility Consultant</li>
-    <li>Léonie Watson, Director, TetraLogical</li>
-    <li>Eric Eggert, Co-Founder, outline</li>
-    <li>Dale Reardon - Founder &amp; CEO of TravelForAll.Guide</li>
-    <li>Jason Gill - Certified Web Accessibility Specialist</li>
-    <li>Michael Ausbun, CPWA, Accessibility Specialist</li>
-    <li>Ronny Hendriks - Accessibility Consultant, Toegankelijk Online</li>
-    <li>Charles Hall, Senior Accessibility Designer, CVS Health</li>
-    <li>Hai Nguyen Ly, Accessibility Advocate</li>
-    <li>David Luhr, Accessibility Consultant</li>
-    <li>Justin L. Yarbrough, Accessibility Specialist, Rio Salado College</li>
-    <li>Hidde de Vries, accessibility specialist and front-end developer</li>
-    <li>James Fleeting, Technical Director, Monkee-Boy</li>
-    <li>Alex Tait, Accessibility Specialist, AT Fresh Solutions</li>
-    <li>Michael Fairchild, Accessibility consultant</li>
-    <li>Gijs Veyfeyken, web accessibility specialist, Five Oaks</li>
-    <li>Dennis Lembree, Web Axe &amp; Easy Chirp</li>
-    <li>Adrian Roselli</li>
-    <li>Rob Whiting, Head of Research &amp; Design, Merlan Ltd.</li>
-    <li>Kitty Giraudel, Accessibility Specialist, Gorillas</li>
-    <li>Derek Mohr, Front-end Developer, Mighty in the Midwest</li>
-    <li>Alastair Campbell, Director of Accessibility, Nomensa</li>
-    <li>Anders Fredericksen, Level Access</li>
-    <li>Zoë Bijl, Senior Accessibility Engineer, CrowdStrike</li>
-    <li>Jonathan Avila, Level Access</li>
-    <li>Sheri Byrne-Haber, Senior accessibility evangelist</li>
-    <li>Jared Smith, Associate Director, WebAIM</li>
-    <li>Kazuhito Kidachi</li>
-    <li>Yakim van Zuijlen, Designer</li>
-    <li>Shannon Urban, Director of Accessibility, EVERFI</li>
-    <li>Todd Libby, Accessibility Advocate and Consultant</li>
-    <li>David Monnehay, Atalan</li>
-    <li>Joschi Kuphal, CPWA &amp; CEO, tollwerk</li>
-    <li>Romain Deltour, web/accessibility/ebook specialist</li>
-    <li>Craig Francis, Code Poets Limited</li>
-    <li>Erik Gustafsson, Accessibility Specialist, Axess Lab</li>
-    <li>Dan Payne, Accessibility consultant</li>
-    <li>Ben Tillyer</li>
-    <li>Matt Obee, Senior Product Designer and accessibility specialist, NearForm</li>
-    <li>Florian Beijers, Accessibility Consultant, Developer, Screenreader User</li>
-    <li>Donna Vitan, Design Systems Nerd</li>
-    <li>Ruben Nic, Web Accessibility/Senior Engineer, Webflow</li>
-    <li>Dennis Deacon, Accessibility Consultant</li>
-    <li>Nicolas Loye, CTO, Actency</li>
-    <li>Rachele DiTullio, accessibility engineer, CPWA</li>
-    <li>Gerard K. Cohen, self</li>
-    <li>Dr. Kate Deibel, Inclusion and Accessibility Librarian, Syracuse University Libraries</li>
-    <li>Vincent Aniort, digital accessibility expert, Orange SA</li>
-    <li>Arthur Rigaud, Accessibility Specialist and Front-End Developer</li>
-    <li>Gary Jones, WordPress VIP</li>
-    <li>Andrew Nevins, CPWA, Front-end developer</li>
-    <li>Chris Heilmann, Principal Product Manager for Developer Tools</li>
-    <li>Bruce Lawson, greedy accessibility consultant</li>
-    <li>Peter Goes, Front-end developer, De Voorhoede</li>
-    <li>Geoff Mortstock, Accessibility Consultant</li>
-    <li>Marcus Herrmann, Web Accessibility Specialist and front-end developer</li>
-    <li>Kelly Childs, Lead Developer, Be Accessible, Inc.</li>
-    <li>Matthew Hallonbacka</li>
-    <li>Kelly Wills, Access Technology Specialist, CPWA</li>
-    <li>Joan Preston, Web Accessibility Coordinator, California State University, Long Beach</li>
-    <li>Jon Gibbins, digital accessibility consultant, Dotjay Ltd</li>
-    <li>Alicia Jarvis</li>
-    <li>Jennifer Strickland, Senior HCD + Accessibility Engineer at MITRE, Accessibility Consultant at Level Access</li>
-    <li>Lainey Feingold - lawyer and author, Law Office of Lainey Feingold</li>
-    <li>Andrew Hayward, Accessibility Engineer</li>
-    <li>Jean Ducrot, Accessibility Engineer, CPWA</li>
-    <li>Manuel Razzari - Accessibility educator, Buenos Aires National Technological University, Argentina</li>
-    <li>Zack Kline, Accessibility Tester, ISoftStone</li>
-    <li>Anna E. Cook - Senior Product Designer and Accessibility Specialist</li>
-    <li>Christophe Strobbe, researcher and lecturer in HCI and accessibility, Stuttgart Media University</li>
-    <li>Eric Bailey, The A11Y Project Maintainer</li>
-    <li>Andre Polykanine, software engineer, web accessibility specialist, screen reader user</li>
-    <li>Ben Myers, Software Engineer</li>
-    <li>Eric Bednarz, self</li>
-    <li>Olivier Keul, Accessibility consultant, Temesis</li>
-    <li>Bogdan Cerovac, WAS, front-end developer and accessibility lead</li>
-    <li>Lori Samuels, Accessibility Director, NBCUniversal</li>
-    <li>Ryan Leisinger - UX Manager Department of Licensing WA State</li>
-    <li>Ian Lloyd, Accessibility Engineer</li>
-    <li>Pavel Pomerantsev, web accessibility engineer, Squarespace</li>
-    <li>Dominik Wilkowski, People Director, Thinkmill</li>
-    <li>Rowdy Rabouw, web and app developer, double-R webdevelopment</li>
-    <li>Jen Smith, Accessibility Program Manager, Microsoft</li>
-    <li>Toufic Sbeiti, accessibility advocate</li>
-    <li>Amy Carney, CPWA, accessibility consultant &amp; front-end web developer, Digilou</li>
-    <li>Carly Gerard CPWA, Web Accessibility Engineer, Western Washington University</li>
-    <li>Haben Girma, Human Rights Lawyer</li>
-    <li>Katriel Paige, Accessibility Consultant, Fox Design Studios LLC</li>
-    <li>Adrianne Mallett, Software Engineer</li>
-    <li>Krista Greear</li>
-    <li>Kim Krause Berg, CPACC Accessibility and UX Consultant</li>
-    <li>Joseph Dolson</li>
-    <li>Ashley Hannan, Accessibility Advocate</li>
-    <li>Cara Hall, Accessibility Advocate</li>
-    <li>Paul Grenier, Web Developer</li>
-    <li>Glenda Sims, Accessibility consultant</li>
-    <li>JF Hector Labram, WAS, Principal Front-End Engineer, Kooth Plc</li>
-    <li>Anne-Mieke Bovelett, Accessibility Advocate</li>
-    <li>Radimir Bitsov, Web Accessibility and Performance Engineer</li>
-    <li>Beatriz González Mellídez, Principal Product Design, CPWA, CPUX-RE</li>
-    <li>Wilfred Nas, Product Owner / User interface consultant</li>
-    <li>Shawn Thompson, Digital Accessibility Advocate</li>
-    <li>Kim Johannesen, CEO and Accessibility Consultant, Shift ApS</li>
-    <li>Marco Hengstenberg, Front End Web Developer and Accessibility Consultant</li>
-    <li>Nicola Saunders, Front-End Developer, Studio 24 Ltd
-    <li>Rogier Barendregt, Senior digital product designer, Rg/B</li>
-    <li>Jeremy Keith, Founder, Clearleft</li>
-    <li>Kasper Isager, Software Developer</li>
-    <li>Angela P. Ricci, Web Designer/ Front dev</li>
-    <li>Matt Jiggins, Developer/Designer</li>
-    <li>Stefan Wajda, LepszyWeb.pl, digital accessibility specialist</li>
-    <li>Sina Bahram, President, Prime Access Consulting, Inc.</li>
-    <li>Kristina England, Accessibility Specialist, University of Massachusetts President's Office</li>
-    <li>Birkir Gunnarsson, CPWA, digital accessibility lead</li>
-    <li>Kerstin Probiesch, Accessibility Consultant</li>
-    <li>Radek Pavlíček, CPWA, Accessibility Specialist, Teiresias Centre Masaryk University & Poslepu.cz</li>
-    <li>Billy Gregory, TPGi</li>
-    <li>Thomas Logan</li>
-    <li>Brian Elton, Accessibility Engineer/Consultant</li>
-    <li>Kevin Mar-Molinero, Director of Experience Technologies Kin+Carta Connect, Member of BIMA Inclusive Design
-      Council.</li>
-    <li>Crystal Preston-Watson, Quality and Accessibility Engineer</li>
-    <li>Bob Dodd, Accessibility Consultant</li>
-    <li>Chauncey McAskill</li>
-    <li>David Swallow, Accessibility Engineer</li>
-    <li>Marko Milanović, Developer, Tenon.io</li>
-    <li>Joe Lamyman, Development Specialist</li>
-    <li>Kevin Ackley, Accessibility Tech Consultant</li>
-    <li>Stephen Clower, Software Developer and Accessibility Lead, Desmos, Inc.</li>
-    <li>Nicolas Chardon, Digital Accessibility Expert</li>
-    <li>Steve Faulkner, Chief Accessibility Officer, TPGi</li>
-    <li>Andy Bell, Designer and Educator</li>
-    <li>Patrick H. Lauke, Accessibility Trash Panda</li>
-    <li>Yann Kozon, Front End Web Developer and Accessibility Consultant, Freelance</li>
-    <li>Chris Taylor, Web Nerd, Yorkshire Twist</li>
-    <li>Miriam Suzanne, Agency Co-Founder & W3C Invited Expert</li>
-    <li>Robert Jolly, Product Manager &amp; Accessibility Strategist</li>
-    <li>Lena Chandelier, Accessibility Expert, Front-end Developer</li>
-    <li>Thomas Parisot, Old Timey Web Developer</li>
-    <li>Jesse Menn, Principal Web Developer</li> 
-    <li>Wendy Reid, Accessibility Lead</li> 
-    <li>Scott O'Hara, Accessibility Engineer/Consultant</li>
-    <li>Phil Springall</li>
-    <li>Dr Carl Myhill, Director, User Experience Design Limited</li>
-    <li>Sumner M. Davenport, Specialist Web Accessibility</li>
-    <li>Dana Byerly, Interaction Designer</li>
-    <li>Jamie Knight, self</li>
-    <li>Matt Richardson, Web Accessibility Expert</li>
-    <li>Josephine Schwebler, Senior Consultant Accessibility / Accessible Documents</li>
-    <li>Vegard Haugstvedt, Front-end Developer / Accessibility Specialist, Webstep</li>
-    <li>Mikołaj Rotnicki, http://a11y.report, accessibility specialist</li>
-    <li>William Bunch - Accessibility Consultant</li>
-    <li>Kris Rivenburgh, Chief Accessibility & Legal Officer, Essential Accessibility</li>
-    <li>Paul Kruczynski, Front-End UX/UI Developer</li>
-    <li>Matthias Weston, Accessibility-Centered Freelance Developer</li>
-    <li>Mat Harris, Accessibility Consultant</li>
-    <li>Lindsey Dragun, Developer / Accessibility Advocate</li>
-    <li>Michail Yasonik, Senior Software Engineer</li>
-    <li>Marcy Sutton, Independent Web Developer and Accessibility Specialist</li>
-	<li>Talita Pagani, Accessibility and UX Consultant, Research Scientist in Web Accessibility for Neurodiversity</li>
-    <li>Aaron Chu, UI Engineer + Disability & Design Researcher</li>
-    <li>Adam Saucier, Web Accessibility Specialist</li>
-    <li>Arnaud Delafosse, Web Quality & Accessibility Consultant, Temesis</li>
-    <li>J.J. Meddaugh, Owner, A. T. Guys.</li>
-    <li>Nicki Rios, CPWA, Founder, Accessibility Consultant &amp; Engineer, Nock &amp; Sparrow</li>
-    <li>John E Brandt, head dude, jebswebs</li>
-    <li>Heather Gray, Website Developer</li>
-    <li>Santina Croniser, Senior Accessibility Engineer, VMware</li>
-    <li>Stein Erik Skotkjerra, Accessibility consultant, CEO, Inklusio</li>
-    <li>Bruno Pulis, Accessibility Advocate, Creator of Awesome A11y</li>
-    <li>Brittany Roots, Accessibility Consultant</li>
-    <li>James Nurthen, Accessibility Engineer & co-chair ARIA Working Group</li>
-    <li>Shell Little, Inclusive Design Lead and Digital Accessibility Specialist</li>
-  </ol>
-  <p><a href="https://github.com/karlgroves/overlayfactsheet/">Add your name to this list on GitHub</a></p>
-</div>
-<div class="further-reading">
+        <blockquote id="wilfsplodnokit" class="quote">
+          …I finally managed to gain access to my @NameCheap account by blocking
+          #AccessiBe in my Windows Hosts file. I should not need to do this to use
+          the Internet. AccessiBe needs to AccessiBeGone
+          <cite>
+            <a class="quote-source" href="https://twitter.com/WilfSplodNokit/status/1365478393895153664">WilfSplodNokit</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="geauxender" class="quote">
+          …I know with 100% certainty, any site which has deployed an overlay in
+          the past year and a half has been less useable for both my wife and
+          me—both blind.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/GeauxEnder/status/1364943889132646408">GeauxEnder</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="big_d01" class="quote">
+          …Still a pain to even try reading the article on a mobile device
+          because of the constant interruption every few seconds. Considering
+          every site using your service also has this problem… Nope.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/Big_D01/status/1365187231829254144">Big_D01</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="w9fyi" class="quote">
+          …Making a webpage accessible does take work, and simply telling a
+          business they can install your plugin is absolutely foolish, you build,
+          and design accessibility in to a webpage using WCAG standards.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/w9fyi/status/1366019424415866880">w9fyi</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="kevmarmol_ct" class="quote">
+          …Suggesting one line of code is cheap so you should do it by inference
+          suggests disabled lives aren't worth investing in either. #a11y
+          <cite>
+            <a class="quote-source" href="https://twitter.com/Kevmarmol_CT/status/1365005141594750986">Kevmarmol_CT</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="eluberoff" class="quote">
+          @AccessiBe Just to demonstrate my good faith, here's a quick free audit
+          of https://t.co/1mQGCCtnIs. You capture &quot;tab&quot; which is the
+          standard way to navigate. There's no way to not enable your overlay if
+          I want to navigate the page. Once the overlay is enabled, wild things
+          happen.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/eluberoff/status/1366386598770839557">eluberoff</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="turtlecatpurrz" class="quote">
+          #AccessiBe makes sites harder to use by getting in the way of browsing
+          and changing access barriers on a page, not fixing them. A student and I
+          came across an &quot;enhanced&quot; website and to my shame, we left
+          because navigating that mess was beyond my skills, on that day.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/turtlecatpurrz/status/1365099776207851523">turtlecatpurrz</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="singingtigress" class="quote">
+          Accessibility overlays are not the answer, and AccessiBe is no exception.
+          As a screen reader user, numerous sites have become less usable for me
+          with this overlay. Discrediting reputable accessiblity professionals and
+          advocates will not sway me on this view. https://t.co/ZgFt8JtsbZ
+          <cite>
+            <a class="quote-source" href="https://twitter.com/SingingTigress/status/1364922970670583815">SingingTigress</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="marcozehe" class="quote" lang="de">
+          An die Screen Reader nutzenden Follower: Vielleicht habt ihr schon von
+          #Accessibe gehört, einem Overlay, das behauptet, Seiten, in denen es
+          eingebunden ist, zugänglicher zu machen. Ich möchte nicht näher ins
+          Detail gehen. Kurz gesagt: Kompletter Blödsinn. Finger weg!
+          <cite>
+            <a class="quote-source" href="https://twitter.com/MarcoZehe/status/1365587195596181507">MarcoZehe</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="twithoff" class="quote">
+          Automated solutions which promise to make your site accessible can't. It
+          takes more than automation to achieve this requirement. You won't be safe
+          from liability. you will almost assuredly negatively impact your
+          customers with disabilities.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/twithoff/status/1364957890050686976">twithoff</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="borrisinabox" class="quote">
+          Every time I go on a website and I hear the #accessiBe notification that
+          this site is adjusted to my screen reader, I know that my blocker isn't
+          working properly, and I'm in for a hellish experience on that particular website.
+          https://t.co/ZFzKMfUe0t
+          <cite>
+            <a class="quote-source" href="https://twitter.com/BorrisInABox/status/1364295702696890370">BorrisInABox</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="racheleditullio" class="quote">
+          I tried using this @AccessiBe site with VoiceOver in Chrome on iOS.
+          The 4-star rating is announced as &quot;unpronounceable&quot;
+          🤦‍♀️ https://t.co/f4MxQ2eLLP"
+          <cite>
+            <a class="quote-source"
+              href="https://twitter.com/racheleditullio/status/1365739183839588357">racheleditullio</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="kit_flowerstorm" class="quote">
+          I wrote an email to their customer service detailing that I can not use
+          their site due to the overlay, but… I really am disappointed, but I hope
+          they listen. @Goodfair_ - please stop using AccessiBe.
+          <cite>
+            <a class="quote-source"
+              href="https://twitter.com/kit_flowerstorm/status/1364605580405575681">kit_flowerstorm</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="atfarnum" class="quote">
+          I'm not an accessibility expert, just a screen reader user with decent
+          skills telling you that this thread is spot on and my experience with
+          #AccessiBe is that it makes sites with accessibility issues even harder
+          to work around. https://t.co/cfyrEqXwTy
+          <cite>
+            <a class="quote-source" href="https://twitter.com/atfarnum/status/1365075850861887490">atfarnum</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="smartudlab" class="quote">
+          …If you are blind or low vision and rely on assistive technologies like
+          screen readers, you may have begun finding popular websites becoming less
+          usable… this page describes how to ban AccessiBe from ever reaching your
+          computer… https://t.co/qbiKvolizS
+          <cite>
+            <a class="quote-source" href="https://twitter.com/smartudlab/status/1365651400638615559">smartudlab</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="kellylford" class="quote">
+          OK, this seems very wrong to me. A local chain here named Fleet Farm is
+          now using AccessiBe. It makes a mess of the search for location feature.
+          This is what I now get on the start of the result page.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/kellylford/status/1363698942152757253">kellylford</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="mhorspool" class="quote">
+          Thank goodness Firefox blocks their accessibility detection. For me,
+          focus jumps all over the place with #AccessiBe enabled. When it's
+          disabled, it behaves itself.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/mhorspool/status/1364983194546757634">mhorspool</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="cswordpress" class="quote">
+          There are 0 automated tools that can tetect accessibility problems
+          accurately at anything above 30% of the time. 0. This is commonly known
+          by anyone who's been in this space for at least a week. #AccessiBe
+          <cite>
+            <a class="quote-source" href="https://twitter.com/cswordpress/status/1365042078401576968">cswordpress</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="wtbdavidg" class="quote">
+          There's a perfectly practical tool for making websites accessible. It's
+          called a programmer. The needs that matter in making a website accessible
+          are those of the users. If you can't meet those, then you can't meet the
+          basic costs of doing business.
+          <cite>
+            <a class="quote-source" href="https://twitter.com/WTBDavidG/status/1366074519086055425">WTBDavidG</a>
+          </cite>
+        </blockquote>
+
+        <blockquote id="catchthesewords" class="quote">
+          When #AccessiBe is enabled, the page is flooded with headings. Lots of
+          heading level 2's. The title of each phone remains a heading in both
+          versions of the page, but with it enabled, things like cost, display, and
+          all the other components of the tables become headings as well.
+          <cite>
+            <a class="quote-source"
+              href="https://twitter.com/CatchTheseWords/status/1364915942157922308">CatchTheseWords</a>
+          </cite>
+        </blockquote>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
+    <h2 id="conclusion">
+      Conclusion
+    </h2>
+    <p class="summary">
+      No overlay product on the market can cause a website to become fully
+      compliant with any existing accessibility standard and therefore cannot
+      eliminate legal risk.
+    </p>
+    <p>Accessibility on the Web is a big challenge, both for owners of websites
+      and for the users of those websites. The invention of novel approaches to
+      resolving this challenge is to be commended.</p>
+    <p>However, in the case of overlays—especially those which attempt to add
+      widgets that present assistive features—the challenge is not being met. Even
+      more problematic are the deceptive marketing provided by some overlay
+      vendors who promise that implementing their product will give their
+      customer's sites immediate compliance with laws and standards.</p>
+
+    <h2 id="statement-from-sponsors-and-signatories-to-this-fact-sheet">
+      Statement from sponsors and signatories to this fact sheet
+    </h2>
+    <p>As a result of the above information:</p>
+    <ol>
+      <li>We will never advocate, recommend, or integrate an overlay which
+        deceptively markets itself as providing automated compliance with laws
+        or standards.
+      </li>
+      <li>We will always advocate for the remediation of accessibility issues at
+        the source of the original error.
+      </li>
+      <li>We will refuse to stay silent when overlay vendors use deception to
+        market their products.
+      </li>
+      <li>More specifically, we hereby advocate for the removal of accessiBe,
+        AudioEye, UserWay, User1st, MK-Sense, MaxAccess, and all similar products and
+        encourage the site owners who've implemented these products to use more
+        robust, independent, and permanent strategies to making their sites
+        more accessible.
+      </li>
+    </ol>
+  </div>
+
+  <div class="container">
+    <h3>Signed by:</h3>
+    <!--//
+      Add your name to this list in accordance with the guidance provided in the repository's README document
+    //-->
+    <ol>
+      <li>Karl Groves, Founder and President, Tenon.io</li>
+      <li>Nicolas Steenhout, Independent accessibility consultant</li>
+      <li>Rian Rietveld, web accessibility specialist, Level Level</li>
+      <li>Weston Thayer, Founder, Assistiv Labs</li>
+      <li>Denis Boudreau, Accessibility consultant</li>
+      <li>Meryl K. Evans, accessibility advocate</li>
+      <li>Makoto Ueki, Web accessibility consultant, Infoaxia</li>
+      <li>Michael Spellacy, Accessibility Consultant</li>
+      <li>Helen Burge, Accessibility Consultant</li>
+      <li>Léonie Watson, Director, TetraLogical</li>
+      <li>Eric Eggert, Co-Founder, outline</li>
+      <li>Dale Reardon - Founder &amp; CEO of TravelForAll.Guide</li>
+      <li>Jason Gill - Certified Web Accessibility Specialist</li>
+      <li>Michael Ausbun, CPWA, Accessibility Specialist</li>
+      <li>Ronny Hendriks - Accessibility Consultant, Toegankelijk Online</li>
+      <li>Charles Hall, Senior Accessibility Designer, CVS Health</li>
+      <li>Hai Nguyen Ly, Accessibility Advocate</li>
+      <li>David Luhr, Accessibility Consultant</li>
+      <li>Justin L. Yarbrough, Accessibility Specialist, Rio Salado College</li>
+      <li>Hidde de Vries, accessibility specialist and front-end developer</li>
+      <li>James Fleeting, Technical Director, Monkee-Boy</li>
+      <li>Alex Tait, Accessibility Specialist, AT Fresh Solutions</li>
+      <li>Michael Fairchild, Accessibility consultant</li>
+      <li>Gijs Veyfeyken, web accessibility specialist, Five Oaks</li>
+      <li>Dennis Lembree, Web Axe &amp; Easy Chirp</li>
+      <li>Adrian Roselli</li>
+      <li>Rob Whiting, Head of Research &amp; Design, Merlan Ltd.</li>
+      <li>Kitty Giraudel, Accessibility Specialist, Gorillas</li>
+      <li>Derek Mohr, Front-end Developer, Mighty in the Midwest</li>
+      <li>Alastair Campbell, Director of Accessibility, Nomensa</li>
+      <li>Anders Fredericksen, Level Access</li>
+      <li>Zoë Bijl, Senior Accessibility Engineer, CrowdStrike</li>
+      <li>Jonathan Avila, Level Access</li>
+      <li>Sheri Byrne-Haber, Senior accessibility evangelist</li>
+      <li>Jared Smith, Associate Director, WebAIM</li>
+      <li>Kazuhito Kidachi</li>
+      <li>Yakim van Zuijlen, Designer</li>
+      <li>Shannon Urban, Director of Accessibility, EVERFI</li>
+      <li>Todd Libby, Accessibility Advocate and Consultant</li>
+      <li>David Monnehay, Atalan</li>
+      <li>Joschi Kuphal, CPWA &amp; CEO, tollwerk</li>
+      <li>Romain Deltour, web/accessibility/ebook specialist</li>
+      <li>Craig Francis, Code Poets Limited</li>
+      <li>Erik Gustafsson, Accessibility Specialist, Axess Lab</li>
+      <li>Dan Payne, Accessibility consultant</li>
+      <li>Ben Tillyer</li>
+      <li>Matt Obee, Senior Product Designer and accessibility specialist, NearForm</li>
+      <li>Florian Beijers, Accessibility Consultant, Developer, Screenreader User</li>
+      <li>Donna Vitan, Design Systems Nerd</li>
+      <li>Ruben Nic, Web Accessibility/Senior Engineer, Webflow</li>
+      <li>Dennis Deacon, Accessibility Consultant</li>
+      <li>Nicolas Loye, CTO, Actency</li>
+      <li>Rachele DiTullio, accessibility engineer, CPWA</li>
+      <li>Gerard K. Cohen, self</li>
+      <li>Dr. Kate Deibel, Inclusion and Accessibility Librarian, Syracuse University Libraries</li>
+      <li>Vincent Aniort, digital accessibility expert, Orange SA</li>
+      <li>Arthur Rigaud, Accessibility Specialist and Front-End Developer</li>
+      <li>Gary Jones, WordPress VIP</li>
+      <li>Andrew Nevins, CPWA, Front-end developer</li>
+      <li>Chris Heilmann, Principal Product Manager for Developer Tools</li>
+      <li>Bruce Lawson, greedy accessibility consultant</li>
+      <li>Peter Goes, Front-end developer, De Voorhoede</li>
+      <li>Geoff Mortstock, Accessibility Consultant</li>
+      <li>Marcus Herrmann, Web Accessibility Specialist and front-end developer</li>
+      <li>Kelly Childs, Lead Developer, Be Accessible, Inc.</li>
+      <li>Matthew Hallonbacka</li>
+      <li>Kelly Wills, Access Technology Specialist, CPWA</li>
+      <li>Joan Preston, Web Accessibility Coordinator, California State University, Long Beach</li>
+      <li>Jon Gibbins, digital accessibility consultant, Dotjay Ltd</li>
+      <li>Alicia Jarvis</li>
+      <li>Jennifer Strickland, Senior HCD + Accessibility Engineer at MITRE, Accessibility Consultant at Level Access</li>
+      <li>Lainey Feingold - lawyer and author, Law Office of Lainey Feingold</li>
+      <li>Andrew Hayward, Accessibility Engineer</li>
+      <li>Jean Ducrot, Accessibility Engineer, CPWA</li>
+      <li>Manuel Razzari - Accessibility educator, Buenos Aires National Technological University, Argentina</li>
+      <li>Zack Kline, Accessibility Tester, ISoftStone</li>
+      <li>Anna E. Cook - Senior Product Designer and Accessibility Specialist</li>
+      <li>Christophe Strobbe, researcher and lecturer in HCI and accessibility, Stuttgart Media University</li>
+      <li>Eric Bailey, The A11Y Project Maintainer</li>
+      <li>Andre Polykanine, software engineer, web accessibility specialist, screen reader user</li>
+      <li>Ben Myers, Software Engineer</li>
+      <li>Eric Bednarz, self</li>
+      <li>Olivier Keul, Accessibility consultant, Temesis</li>
+      <li>Bogdan Cerovac, WAS, front-end developer and accessibility lead</li>
+      <li>Lori Samuels, Accessibility Director, NBCUniversal</li>
+      <li>Ryan Leisinger - UX Manager Department of Licensing WA State</li>
+      <li>Ian Lloyd, Accessibility Engineer</li>
+      <li>Pavel Pomerantsev, web accessibility engineer, Squarespace</li>
+      <li>Dominik Wilkowski, People Director, Thinkmill</li>
+      <li>Rowdy Rabouw, web and app developer, double-R webdevelopment</li>
+      <li>Jen Smith, Accessibility Program Manager, Microsoft</li>
+      <li>Toufic Sbeiti, accessibility advocate</li>
+      <li>Amy Carney, CPWA, accessibility consultant &amp; front-end web developer, Digilou</li>
+      <li>Carly Gerard CPWA, Web Accessibility Engineer, Western Washington University</li>
+      <li>Haben Girma, Human Rights Lawyer</li>
+      <li>Katriel Paige, Accessibility Consultant, Fox Design Studios LLC</li>
+      <li>Adrianne Mallett, Software Engineer</li>
+      <li>Krista Greear</li>
+      <li>Kim Krause Berg, CPACC Accessibility and UX Consultant</li>
+      <li>Joseph Dolson</li>
+      <li>Ashley Hannan, Accessibility Advocate</li>
+      <li>Cara Hall, Accessibility Advocate</li>
+      <li>Paul Grenier, Web Developer</li>
+      <li>Glenda Sims, Accessibility consultant</li>
+      <li>JF Hector Labram, WAS, Principal Front-End Engineer, Kooth Plc</li>
+      <li>Anne-Mieke Bovelett, Accessibility Advocate</li>
+      <li>Radimir Bitsov, Web Accessibility and Performance Engineer</li>
+      <li>Beatriz González Mellídez, Principal Product Design, CPWA, CPUX-RE</li>
+      <li>Wilfred Nas, Product Owner / User interface consultant</li>
+      <li>Shawn Thompson, Digital Accessibility Advocate</li>
+      <li>Kim Johannesen, CEO and Accessibility Consultant, Shift ApS</li>
+      <li>Marco Hengstenberg, Front End Web Developer and Accessibility Consultant</li>
+      <li>Nicola Saunders, Front-End Developer, Studio 24 Ltd
+      <li>Rogier Barendregt, Senior digital product designer, Rg/B</li>
+      <li>Jeremy Keith, Founder, Clearleft</li>
+      <li>Kasper Isager, Software Developer</li>
+      <li>Angela P. Ricci, Web Designer/ Front dev</li>
+      <li>Matt Jiggins, Developer/Designer</li>
+      <li>Stefan Wajda, LepszyWeb.pl, digital accessibility specialist</li>
+      <li>Sina Bahram, President, Prime Access Consulting, Inc.</li>
+      <li>Kristina England, Accessibility Specialist, University of Massachusetts President's Office</li>
+      <li>Birkir Gunnarsson, CPWA, digital accessibility lead</li>
+      <li>Kerstin Probiesch, Accessibility Consultant</li>
+      <li>Radek Pavlíček, CPWA, Accessibility Specialist, Teiresias Centre Masaryk University &amp; Poslepu.cz</li>
+      <li>Billy Gregory, TPGi</li>
+      <li>Thomas Logan</li>
+      <li>Brian Elton, Accessibility Engineer/Consultant</li>
+      <li>Kevin Mar-Molinero, Director of Experience Technologies Kin+Carta Connect, Member of BIMA Inclusive Design Council.</li>
+      <li>Crystal Preston-Watson, Quality and Accessibility Engineer</li>
+      <li>Bob Dodd, Accessibility Consultant</li>
+      <li>Chauncey McAskill</li>
+      <li>David Swallow, Accessibility Engineer</li>
+      <li>Marko Milanović, Developer, Tenon.io</li>
+      <li>Joe Lamyman, Development Specialist</li>
+      <li>Kevin Ackley, Accessibility Tech Consultant</li>
+      <li>Stephen Clower, Software Developer and Accessibility Lead, Desmos, Inc.</li>
+      <li>Nicolas Chardon, Digital Accessibility Expert</li>
+      <li>Steve Faulkner, Chief Accessibility Officer, TPGi</li>
+      <li>Andy Bell, Designer and Educator</li>
+      <li>Patrick H. Lauke, Accessibility Trash Panda</li>
+      <li>Yann Kozon, Front End Web Developer and Accessibility Consultant, Freelance</li>
+      <li>Chris Taylor, Web Nerd, Yorkshire Twist</li>
+      <li>Miriam Suzanne, Agency Co-Founder &amp; W3C Invited Expert</li>
+      <li>Robert Jolly, Product Manager &amp; Accessibility Strategist</li>
+      <li>Lena Chandelier, Accessibility Expert, Front-end Developer</li>
+      <li>Thomas Parisot, Old Timey Web Developer</li>
+      <li>Jesse Menn, Principal Web Developer</li>
+      <li>Wendy Reid, Accessibility Lead</li>
+      <li>Scott O'Hara, Accessibility Engineer/Consultant</li>
+      <li>Phil Springall</li>
+      <li>Dr Carl Myhill, Director, User Experience Design Limited</li>
+      <li>Sumner M. Davenport, Specialist Web Accessibility</li>
+      <li>Dana Byerly, Interaction Designer</li>
+      <li>Jamie Knight, self</li>
+      <li>Matt Richardson, Web Accessibility Expert</li>
+      <li>Josephine Schwebler, Senior Consultant Accessibility / Accessible Documents</li>
+      <li>Vegard Haugstvedt, Front-end Developer / Accessibility Specialist, Webstep</li>
+      <li>Mikołaj Rotnicki, http://a11y.report, accessibility specialist</li>
+      <li>William Bunch - Accessibility Consultant</li>
+      <li>Kris Rivenburgh, Chief Accessibility &amp; Legal Officer, Essential Accessibility</li>
+      <li>Paul Kruczynski, Front-End UX/UI Developer</li>
+      <li>Matthias Weston, Accessibility-Centered Freelance Developer</li>
+      <li>Mat Harris, Accessibility Consultant</li>
+      <li>Lindsey Dragun, Developer / Accessibility Advocate</li>
+      <li>Michail Yasonik, Senior Software Engineer</li>
+      <li>Marcy Sutton, Independent Web Developer and Accessibility Specialist</li>
+    <li>Talita Pagani, Accessibility and UX Consultant, Research Scientist in Web Accessibility for Neurodiversity</li>
+      <li>Aaron Chu, UI Engineer + Disability &amp; Design Researcher</li>
+      <li>Adam Saucier, Web Accessibility Specialist</li>
+      <li>Arnaud Delafosse, Web Quality &amp; Accessibility Consultant, Temesis</li>
+      <li>J.J. Meddaugh, Owner, A. T. Guys.</li>
+      <li>Nicki Rios, CPWA, Founder, Accessibility Consultant &amp; Engineer, Nock &amp; Sparrow</li>
+      <li>John E Brandt, head dude, jebswebs</li>
+      <li>Heather Gray, Website Developer</li>
+      <li>Santina Croniser, Senior Accessibility Engineer, VMware</li>
+      <li>Stein Erik Skotkjerra, Accessibility consultant, CEO, Inklusio</li>
+      <li>Bruno Pulis, Accessibility Advocate, Creator of Awesome A11y</li>
+      <li>Brittany Roots, Accessibility Consultant</li>
+      <li>James Nurthen, Accessibility Engineer &amp; co-chair ARIA Working Group</li>
+      <li>Shell Little, Inclusive Design Lead and Digital Accessibility Specialist</li>
+    </ol>
+    <p>
+      <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">
+        Add your name to this list
+      </a>
+    </p>
+  </div>
+</main>
+
+<aside class="further-reading">
   <div class="container">
     <h2 id="additional-reading">Additional Reading</h2>
     <ul>
@@ -692,12 +701,11 @@
       <li><a
         href="https://barrierekompass.de/aktuelles/detail/guenstig-oder-kostenlos-barrierefrei-mit-kuenstlicher-intelligenz-ki.html">German
         Article on Overlays: <span
-          lang="de-DE">Günstig oder kostenlos – barrierefrei mit Künstlicher Intelligenz (KI)? </span></a>
+          lang="de-DE">Günstig oder kostenlos – barrierefrei mit Künstlicher Intelligenz (KI)?</span></a>
         <span class="further-reading-source" lang="de-DE">Barriere Kompass</span>
-
       </li>
     </ul>
   </div>
-</div>
+</aside>
 </body>
 </html>

--- a/src/screen.css
+++ b/src/screen.css
@@ -13,6 +13,7 @@
 
 /* Custom properties */
 :root {
+  --border-radius: 0.5rem;
   --border-thickness: 2px;
   --color-gray-100: #ffffff;
   --color-gray-200: #eaeaea;
@@ -136,6 +137,9 @@ blockquote {
 
 a {
   color: var(--color-red-700);
+  transition:
+  150ms background-color ease-in-out,
+  150ms color ease-in-out;
 }
 
 a:hover,
@@ -246,9 +250,26 @@ a:focus {
 .quote {
   background-color: var(--color-gray-100);
   border: var(--border-thickness) solid var(--color-red-200);
-  border-radius: 0.5rem;
+  border-radius: var(--border-radius);
   margin-top: calc(var(--vertical-rhythm) * 2);
   padding: 2rem;
+}
+
+.add-your-name {
+  background: var(--color-yellow-100);
+  border: var(--border-thickness) solid var(--color-yellow-500);
+  border-radius: var(--border-radius);
+  color: var(--color-yellow-800);
+  display: inline-block;
+  font-size: 1.25rem;
+  margin-top: var(--vertical-rhythm);
+  padding: 1rem 2rem;
+}
+
+.add-your-name:hover,
+.add-your-name:focus {
+  background: var(--color-yellow-300);
+  color: var(--color-yellow-900);
 }
 
 @supports (display: grid) {
@@ -315,7 +336,7 @@ a:focus {
   .quote {
     background-color: var(--color-gray-900);
     border: var(--border-thickness) solid var(--color-red-800);
-    border-radius: 0.5rem;
+    border-radius: var(--border-radius);
     margin-top: calc(var(--vertical-rhythm) * 2);
     padding: 2rem;
   }

--- a/src/screen.css
+++ b/src/screen.css
@@ -116,10 +116,14 @@ p {
   margin-top: var(--vertical-rhythm);
 }
 
-ul,
-ol {
+ul {
   margin-top: var(--vertical-rhythm);
   margin-left: 2rem;
+}
+
+ol {
+  margin-top: var(--vertical-rhythm);
+  margin-left: 3rem;
 }
 
 li {
@@ -165,6 +169,30 @@ a:focus {
 .further-reading {
   margin-top: calc(var(--vertical-rhythm) * 2);
   padding: 0 2rem 4rem 2rem;
+}
+
+.quotes {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+@supports (display: grid) {
+  .quotes {
+    margin-top: var(--vertical-rhythm);
+  }
+}
+
+@media screen and (min-width: 60rem) {
+  .quotes {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media screen and (min-width: 80rem) {
+  .quotes {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
 }
 
 .in-their-own-words {
@@ -221,6 +249,12 @@ a:focus {
   border-radius: 0.5rem;
   margin-top: calc(var(--vertical-rhythm) * 2);
   padding: 2rem;
+}
+
+@supports (display: grid) {
+  .quote {
+    margin-top: 0;
+  }
 }
 
 .quote cite {


### PR DESCRIPTION
This PR:

- Links directly to the endorse subsection in the README from the "Add your name to this list" link
- Makes the "Add your name to this list" link more visually prominent
- Adds document landmarks
- Adds a grid for "in their own words" quotes

<img width="1519" alt="A 3 column grid of quotes from the Overlay Fact Sheet website." src="https://user-images.githubusercontent.com/634191/111237166-e661f700-85ca-11eb-8496-00bd5de78c8e.png">
