### PR TITLE
Fix stray div, escape ampersands

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -168,211 +168,210 @@
         comments are par-for-the-course when it comes to the user experience
         provided by overlay widgets which have, in themselves, a pattern of
         negatively impacting the user experience.</p>
-      </div>
+    </div>
 
-      <div class="quotes">
-        <blockquote id="derekriemer" class="quote">
-          …assuming your tool can do a good job making something accessible, it can
-          do an even better job making something accessible running directly on the
-          user's machine having access to machine code and machine APIs
-          <cite>
-            <a class="quote-source" href="https://twitter.com/DerekRiemer/status/1365136025861775364">DerekRiemer</a>
-          </cite>
-        </blockquote>
+    <div class="quotes">
+      <blockquote id="derekriemer" class="quote">
+        …assuming your tool can do a good job making something accessible, it can
+        do an even better job making something accessible running directly on the
+        user's machine having access to machine code and machine APIs
+        <cite>
+          <a class="quote-source" href="https://twitter.com/DerekRiemer/status/1365136025861775364">DerekRiemer</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="wilfsplodnokit" class="quote">
-          …I finally managed to gain access to my @NameCheap account by blocking
-          #AccessiBe in my Windows Hosts file. I should not need to do this to use
-          the Internet. AccessiBe needs to AccessiBeGone
-          <cite>
-            <a class="quote-source" href="https://twitter.com/WilfSplodNokit/status/1365478393895153664">WilfSplodNokit</a>
-          </cite>
-        </blockquote>
+      <blockquote id="wilfsplodnokit" class="quote">
+        …I finally managed to gain access to my @NameCheap account by blocking
+        #AccessiBe in my Windows Hosts file. I should not need to do this to use
+        the Internet. AccessiBe needs to AccessiBeGone
+        <cite>
+          <a class="quote-source" href="https://twitter.com/WilfSplodNokit/status/1365478393895153664">WilfSplodNokit</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="geauxender" class="quote">
-          …I know with 100% certainty, any site which has deployed an overlay in
-          the past year and a half has been less useable for both my wife and
-          me—both blind.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/GeauxEnder/status/1364943889132646408">GeauxEnder</a>
-          </cite>
-        </blockquote>
+      <blockquote id="geauxender" class="quote">
+        …I know with 100% certainty, any site which has deployed an overlay in
+        the past year and a half has been less useable for both my wife and
+        me—both blind.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/GeauxEnder/status/1364943889132646408">GeauxEnder</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="big_d01" class="quote">
-          …Still a pain to even try reading the article on a mobile device
-          because of the constant interruption every few seconds. Considering
-          every site using your service also has this problem… Nope.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/Big_D01/status/1365187231829254144">Big_D01</a>
-          </cite>
-        </blockquote>
+      <blockquote id="big_d01" class="quote">
+        …Still a pain to even try reading the article on a mobile device
+        because of the constant interruption every few seconds. Considering
+        every site using your service also has this problem… Nope.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/Big_D01/status/1365187231829254144">Big_D01</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="w9fyi" class="quote">
-          …Making a webpage accessible does take work, and simply telling a
-          business they can install your plugin is absolutely foolish, you build,
-          and design accessibility in to a webpage using WCAG standards.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/w9fyi/status/1366019424415866880">w9fyi</a>
-          </cite>
-        </blockquote>
+      <blockquote id="w9fyi" class="quote">
+        …Making a webpage accessible does take work, and simply telling a
+        business they can install your plugin is absolutely foolish, you build,
+        and design accessibility in to a webpage using WCAG standards.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/w9fyi/status/1366019424415866880">w9fyi</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="kevmarmol_ct" class="quote">
-          …Suggesting one line of code is cheap so you should do it by inference
-          suggests disabled lives aren't worth investing in either. #a11y
-          <cite>
-            <a class="quote-source" href="https://twitter.com/Kevmarmol_CT/status/1365005141594750986">Kevmarmol_CT</a>
-          </cite>
-        </blockquote>
+      <blockquote id="kevmarmol_ct" class="quote">
+        …Suggesting one line of code is cheap so you should do it by inference
+        suggests disabled lives aren't worth investing in either. #a11y
+        <cite>
+          <a class="quote-source" href="https://twitter.com/Kevmarmol_CT/status/1365005141594750986">Kevmarmol_CT</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="eluberoff" class="quote">
-          @AccessiBe Just to demonstrate my good faith, here's a quick free audit
-          of https://t.co/1mQGCCtnIs. You capture &quot;tab&quot; which is the
-          standard way to navigate. There's no way to not enable your overlay if
-          I want to navigate the page. Once the overlay is enabled, wild things
-          happen.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/eluberoff/status/1366386598770839557">eluberoff</a>
-          </cite>
-        </blockquote>
+      <blockquote id="eluberoff" class="quote">
+        @AccessiBe Just to demonstrate my good faith, here's a quick free audit
+        of https://t.co/1mQGCCtnIs. You capture &quot;tab&quot; which is the
+        standard way to navigate. There's no way to not enable your overlay if
+        I want to navigate the page. Once the overlay is enabled, wild things
+        happen.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/eluberoff/status/1366386598770839557">eluberoff</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="turtlecatpurrz" class="quote">
-          #AccessiBe makes sites harder to use by getting in the way of browsing
-          and changing access barriers on a page, not fixing them. A student and I
-          came across an &quot;enhanced&quot; website and to my shame, we left
-          because navigating that mess was beyond my skills, on that day.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/turtlecatpurrz/status/1365099776207851523">turtlecatpurrz</a>
-          </cite>
-        </blockquote>
+      <blockquote id="turtlecatpurrz" class="quote">
+        #AccessiBe makes sites harder to use by getting in the way of browsing
+        and changing access barriers on a page, not fixing them. A student and I
+        came across an &quot;enhanced&quot; website and to my shame, we left
+        because navigating that mess was beyond my skills, on that day.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/turtlecatpurrz/status/1365099776207851523">turtlecatpurrz</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="singingtigress" class="quote">
-          Accessibility overlays are not the answer, and AccessiBe is no exception.
-          As a screen reader user, numerous sites have become less usable for me
-          with this overlay. Discrediting reputable accessiblity professionals and
-          advocates will not sway me on this view. https://t.co/ZgFt8JtsbZ
-          <cite>
-            <a class="quote-source" href="https://twitter.com/SingingTigress/status/1364922970670583815">SingingTigress</a>
-          </cite>
-        </blockquote>
+      <blockquote id="singingtigress" class="quote">
+        Accessibility overlays are not the answer, and AccessiBe is no exception.
+        As a screen reader user, numerous sites have become less usable for me
+        with this overlay. Discrediting reputable accessiblity professionals and
+        advocates will not sway me on this view. https://t.co/ZgFt8JtsbZ
+        <cite>
+          <a class="quote-source" href="https://twitter.com/SingingTigress/status/1364922970670583815">SingingTigress</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="marcozehe" class="quote" lang="de">
-          An die Screen Reader nutzenden Follower: Vielleicht habt ihr schon von
-          #Accessibe gehört, einem Overlay, das behauptet, Seiten, in denen es
-          eingebunden ist, zugänglicher zu machen. Ich möchte nicht näher ins
-          Detail gehen. Kurz gesagt: Kompletter Blödsinn. Finger weg!
-          <cite>
-            <a class="quote-source" href="https://twitter.com/MarcoZehe/status/1365587195596181507">MarcoZehe</a>
-          </cite>
-        </blockquote>
+      <blockquote id="marcozehe" class="quote" lang="de">
+        An die Screen Reader nutzenden Follower: Vielleicht habt ihr schon von
+        #Accessibe gehört, einem Overlay, das behauptet, Seiten, in denen es
+        eingebunden ist, zugänglicher zu machen. Ich möchte nicht näher ins
+        Detail gehen. Kurz gesagt: Kompletter Blödsinn. Finger weg!
+        <cite>
+          <a class="quote-source" href="https://twitter.com/MarcoZehe/status/1365587195596181507">MarcoZehe</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="twithoff" class="quote">
-          Automated solutions which promise to make your site accessible can't. It
-          takes more than automation to achieve this requirement. You won't be safe
-          from liability. you will almost assuredly negatively impact your
-          customers with disabilities.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/twithoff/status/1364957890050686976">twithoff</a>
-          </cite>
-        </blockquote>
+      <blockquote id="twithoff" class="quote">
+        Automated solutions which promise to make your site accessible can't. It
+        takes more than automation to achieve this requirement. You won't be safe
+        from liability. you will almost assuredly negatively impact your
+        customers with disabilities.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/twithoff/status/1364957890050686976">twithoff</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="borrisinabox" class="quote">
-          Every time I go on a website and I hear the #accessiBe notification that
-          this site is adjusted to my screen reader, I know that my blocker isn't
-          working properly, and I'm in for a hellish experience on that particular website.
-          https://t.co/ZFzKMfUe0t
-          <cite>
-            <a class="quote-source" href="https://twitter.com/BorrisInABox/status/1364295702696890370">BorrisInABox</a>
-          </cite>
-        </blockquote>
+      <blockquote id="borrisinabox" class="quote">
+        Every time I go on a website and I hear the #accessiBe notification that
+        this site is adjusted to my screen reader, I know that my blocker isn't
+        working properly, and I'm in for a hellish experience on that particular website.
+        https://t.co/ZFzKMfUe0t
+        <cite>
+          <a class="quote-source" href="https://twitter.com/BorrisInABox/status/1364295702696890370">BorrisInABox</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="racheleditullio" class="quote">
-          I tried using this @AccessiBe site with VoiceOver in Chrome on iOS.
-          The 4-star rating is announced as &quot;unpronounceable&quot;
-          🤦‍♀️ https://t.co/f4MxQ2eLLP"
-          <cite>
-            <a class="quote-source"
-              href="https://twitter.com/racheleditullio/status/1365739183839588357">racheleditullio</a>
-          </cite>
-        </blockquote>
+      <blockquote id="racheleditullio" class="quote">
+        I tried using this @AccessiBe site with VoiceOver in Chrome on iOS.
+        The 4-star rating is announced as &quot;unpronounceable&quot;
+        🤦‍♀️ https://t.co/f4MxQ2eLLP"
+        <cite>
+          <a class="quote-source"
+            href="https://twitter.com/racheleditullio/status/1365739183839588357">racheleditullio</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="kit_flowerstorm" class="quote">
-          I wrote an email to their customer service detailing that I can not use
-          their site due to the overlay, but… I really am disappointed, but I hope
-          they listen. @Goodfair_ - please stop using AccessiBe.
-          <cite>
-            <a class="quote-source"
-              href="https://twitter.com/kit_flowerstorm/status/1364605580405575681">kit_flowerstorm</a>
-          </cite>
-        </blockquote>
+      <blockquote id="kit_flowerstorm" class="quote">
+        I wrote an email to their customer service detailing that I can not use
+        their site due to the overlay, but… I really am disappointed, but I hope
+        they listen. @Goodfair_ - please stop using AccessiBe.
+        <cite>
+          <a class="quote-source"
+            href="https://twitter.com/kit_flowerstorm/status/1364605580405575681">kit_flowerstorm</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="atfarnum" class="quote">
-          I'm not an accessibility expert, just a screen reader user with decent
-          skills telling you that this thread is spot on and my experience with
-          #AccessiBe is that it makes sites with accessibility issues even harder
-          to work around. https://t.co/cfyrEqXwTy
-          <cite>
-            <a class="quote-source" href="https://twitter.com/atfarnum/status/1365075850861887490">atfarnum</a>
-          </cite>
-        </blockquote>
+      <blockquote id="atfarnum" class="quote">
+        I'm not an accessibility expert, just a screen reader user with decent
+        skills telling you that this thread is spot on and my experience with
+        #AccessiBe is that it makes sites with accessibility issues even harder
+        to work around. https://t.co/cfyrEqXwTy
+        <cite>
+          <a class="quote-source" href="https://twitter.com/atfarnum/status/1365075850861887490">atfarnum</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="smartudlab" class="quote">
-          …If you are blind or low vision and rely on assistive technologies like
-          screen readers, you may have begun finding popular websites becoming less
-          usable… this page describes how to ban AccessiBe from ever reaching your
-          computer… https://t.co/qbiKvolizS
-          <cite>
-            <a class="quote-source" href="https://twitter.com/smartudlab/status/1365651400638615559">smartudlab</a>
-          </cite>
-        </blockquote>
+      <blockquote id="smartudlab" class="quote">
+        …If you are blind or low vision and rely on assistive technologies like
+        screen readers, you may have begun finding popular websites becoming less
+        usable… this page describes how to ban AccessiBe from ever reaching your
+        computer… https://t.co/qbiKvolizS
+        <cite>
+          <a class="quote-source" href="https://twitter.com/smartudlab/status/1365651400638615559">smartudlab</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="kellylford" class="quote">
-          OK, this seems very wrong to me. A local chain here named Fleet Farm is
-          now using AccessiBe. It makes a mess of the search for location feature.
-          This is what I now get on the start of the result page.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/kellylford/status/1363698942152757253">kellylford</a>
-          </cite>
-        </blockquote>
+      <blockquote id="kellylford" class="quote">
+        OK, this seems very wrong to me. A local chain here named Fleet Farm is
+        now using AccessiBe. It makes a mess of the search for location feature.
+        This is what I now get on the start of the result page.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/kellylford/status/1363698942152757253">kellylford</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="mhorspool" class="quote">
-          Thank goodness Firefox blocks their accessibility detection. For me,
-          focus jumps all over the place with #AccessiBe enabled. When it's
-          disabled, it behaves itself.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/mhorspool/status/1364983194546757634">mhorspool</a>
-          </cite>
-        </blockquote>
+      <blockquote id="mhorspool" class="quote">
+        Thank goodness Firefox blocks their accessibility detection. For me,
+        focus jumps all over the place with #AccessiBe enabled. When it's
+        disabled, it behaves itself.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/mhorspool/status/1364983194546757634">mhorspool</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="cswordpress" class="quote">
-          There are 0 automated tools that can tetect accessibility problems
-          accurately at anything above 30% of the time. 0. This is commonly known
-          by anyone who's been in this space for at least a week. #AccessiBe
-          <cite>
-            <a class="quote-source" href="https://twitter.com/cswordpress/status/1365042078401576968">cswordpress</a>
-          </cite>
-        </blockquote>
+      <blockquote id="cswordpress" class="quote">
+        There are 0 automated tools that can tetect accessibility problems
+        accurately at anything above 30% of the time. 0. This is commonly known
+        by anyone who's been in this space for at least a week. #AccessiBe
+        <cite>
+          <a class="quote-source" href="https://twitter.com/cswordpress/status/1365042078401576968">cswordpress</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="wtbdavidg" class="quote">
-          There's a perfectly practical tool for making websites accessible. It's
-          called a programmer. The needs that matter in making a website accessible
-          are those of the users. If you can't meet those, then you can't meet the
-          basic costs of doing business.
-          <cite>
-            <a class="quote-source" href="https://twitter.com/WTBDavidG/status/1366074519086055425">WTBDavidG</a>
-          </cite>
-        </blockquote>
+      <blockquote id="wtbdavidg" class="quote">
+        There's a perfectly practical tool for making websites accessible. It's
+        called a programmer. The needs that matter in making a website accessible
+        are those of the users. If you can't meet those, then you can't meet the
+        basic costs of doing business.
+        <cite>
+          <a class="quote-source" href="https://twitter.com/WTBDavidG/status/1366074519086055425">WTBDavidG</a>
+        </cite>
+      </blockquote>
 
-        <blockquote id="catchthesewords" class="quote">
-          When #AccessiBe is enabled, the page is flooded with headings. Lots of
-          heading level 2's. The title of each phone remains a heading in both
-          versions of the page, but with it enabled, things like cost, display, and
-          all the other components of the tables become headings as well.
-          <cite>
-            <a class="quote-source"
-              href="https://twitter.com/CatchTheseWords/status/1364915942157922308">CatchTheseWords</a>
-          </cite>
-        </blockquote>
-      </div>
+      <blockquote id="catchthesewords" class="quote">
+        When #AccessiBe is enabled, the page is flooded with headings. Lots of
+        heading level 2's. The title of each phone remains a heading in both
+        versions of the page, but with it enabled, things like cost, display, and
+        all the other components of the tables become headings as well.
+        <cite>
+          <a class="quote-source"
+            href="https://twitter.com/CatchTheseWords/status/1364915942157922308">CatchTheseWords</a>
+        </cite>
+      </blockquote>
     </div>
   </div>
 
@@ -419,7 +418,7 @@
   </div>
 
   <div class="container">
-    <h3>Signed by:</h3>
+    <h3 id="signed-by">Signed by:</h3>
     <!--//
       Add your name to this list in accordance with the guidance provided in the repository's README document
     //-->
@@ -590,7 +589,7 @@
       <li>Lindsey Dragun, Developer / Accessibility Advocate</li>
       <li>Michail Yasonik, Senior Software Engineer</li>
       <li>Marcy Sutton, Independent Web Developer and Accessibility Specialist</li>
-    <li>Talita Pagani, Accessibility and UX Consultant, Research Scientist in Web Accessibility for Neurodiversity</li>
+      <li>Talita Pagani, Accessibility and UX Consultant, Research Scientist in Web Accessibility for Neurodiversity</li>
       <li>Aaron Chu, UI Engineer + Disability &amp; Design Researcher</li>
       <li>Adam Saucier, Web Accessibility Specialist</li>
       <li>Arnaud Delafosse, Web Quality &amp; Accessibility Consultant, Temesis</li>
@@ -610,7 +609,7 @@
       <li>David A. Kennedy, Designer and Accessibility Weekly curator</li>
       <li>Marc Solomon, self</li>
       <li>Ron Stauffer, Founder, Lieder Digital</li>
-      <li>Nick Caskey, CPWA & Senior Accessibility Engineer, VMware Inc.</li>
+      <li>Nick Caskey, CPWA &amp; Senior Accessibility Engineer, VMware Inc.</li>
       <li>Devon Persing, Technical Program Manager and Digital Accessibility Specialist</li>
       <li>Brian Olore, Developer</li>
       <li>Kathleen McMahon, Engineer, Designer, and Speaker</li>
@@ -637,16 +636,12 @@
       <li>Marcelo Sales, Accessibility Specialist, RD (Raia Drogasil)</li>
       <li>Scott Vinkle, Accessibility Specialist, Shopify</li>
       <li>Barry Pollard, Developer</li>
-      <li>Anand Chowdhary, Creative Technologist & Entrepreneur</li>
+      <li>Anand Chowdhary, Creative Technologist &amp; Entrepreneur</li>
       <li>Christian Alden Jacobs, UX Strategist</li>
       <li>Edward Pritchard, Digital Accessibility Consultant</li>
       <li>Hadley Luker, Accessibility Analyst, Level Access</li>
       <li>John Foliot (JF), Independent Accessibility Specialist / W3C Contributor</li>
       <li>Hala Anwar, Inclusive Design Consultant</li>
-      <li>Johnny Taylor, Accessibility Advocate</li>
-      <li>Joel McKinnon, Accessibility Specialist</li>
-      <li>Olivier Nourry, General Manager & CAO, Be Player One</li>
-      <li>Ross Mullen, Director, CANAXESS</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">
@@ -716,7 +711,7 @@
         <span class="further-reading-source">Karl Groves</span>
       </li>
       <li>
-        <a href="https://www.lalutineduweb.fr/en/web-accessibility-overlays-lies-gum-balls/">Web accessibility overlay tools: lies
+        <a href="lalutineduweb.fr/en/web-accessibility-overlays-lies-gum-balls/">Web accessibility overlay tools: lies
           and gum balls</a>
         <span class="further-reading-source">Julie Moynat</span>
       </li>


### PR DESCRIPTION
This PR: 

- Fixes a stray `div` element from the last design update
- Escapes `&` in the signatures list
- Adds an `id` to "Signed by:"