### PR TITLE
New signed name - Tori Clark | index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -798,6 +798,7 @@
       <li>Armony Altinier, CEO & Accessibility Lead, Koena</li>
       <li>Olivier Camon, Web developer</li>
       <li>Liz Hare, PhD, Quantitative Geneticist, Dog Genetics LLC</li>
+      <li>Tori Clark, Accessibility Evangelist and Executive Director, Digital A11ies</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">


### PR DESCRIPTION
Tori Clark (digitala11ies@digitala11ies.org, professional; toriclarka11y@gmail.com, personal) Added name to list