### PR TITLE
Removing Thomson Reuters

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -511,7 +511,7 @@
           <abbr title="Japan">JP</abbr>, <abbr title="Germany">DE</abbr>, <abbr title="France">FR</abbr>,
           <abbr title="Sweden">SE</abbr>, <abbr title="Norway">NO</abbr>, <abbr title="Belgium">BE</abbr>, <abbr title="Poland">PL</abbr>,
           <abbr title="Australia">AU</abbr>, <abbr title="Denmark">DK</abbr>, <abbr title="Israel">IL</abbr>, <abbr title="Chile">CL</abbr> and more</li>
-        <li>Internal accessibility experts for companies like Google, Microsoft, Apple, NBC, Squarespace, BBC, VMWare, Shopify, ServiceNow, Dell, Lyft, HCL, Costco, Expedia, eBay, Cigna, Target, CVS Health, Kijiji, Orange, Pearson, Mitre, Sapient, Thomson Reuters, and Pearson Assessments</li>
+        <li>Internal accessibility experts for companies like Google, Microsoft, Apple, NBC, Squarespace, BBC, VMWare, Shopify, ServiceNow, Dell, Lyft, HCL, Costco, Expedia, eBay, Cigna, Target, CVS Health, Kijiji, Orange, Pearson, Mitre, Sapient, and Pearson Assessments</li>
         <li>Internal accessibility experts from higher education institutions like Syracuse, CSU, Stuttgart Media University, University of Massachusetts, San Francisco State University, Gallaudet University, Carnegie Mellon, West Virginia University, MIT</li>
         <li>Lawyers for the disabled</li>
         <li>Contributors to assistive technology software such as JAWS and NVDA</li>
@@ -771,7 +771,7 @@
       <li>Ka Li, Accessibility Consultant</li>
       <li>Adele M. Beeby, Web Manager, Leicester City Council</li>
       <li>James Scholes, Director of Digital Accessibility, Prime Access Consulting, Inc.</li>
-      <li>Ian Kersey, Senior Accessibility Specialist, Thomson Reuters</li>
+      <li>Ian Kersey, Self</li>
       <li>Aaron Gustafson, Web Standards & Accessibility Advocate</li>
       <li>Wally Zielinski, WAS, Dell Technologies</li>
       <li>Martin Mengele, Front End Developer & Accessibilty Consultant, @accessabilly)</li>
@@ -911,7 +911,7 @@
       <li>Soheil Varamini, CPWA, Accessibility Analyst, Microassist</li>
       <li>Marvin Hunkin, self</li>
       <li>Alison Walden, Accessibility Specialist, Sapient</li>
-      <li>Geetha Somasundaram, Accessibility Specialist, Thomson Reuters</li>
+      <li>Geetha Somasundaram, Self</li>
       <li>Jon Plummer, Director of User Experience, Concentric Sky</li>
       <li>Jason Neel, Senior Web Developer, West Virginia University</li>
       <li>Angela Hooker, self</li>
@@ -1055,7 +1055,7 @@
       <li>Deborah Edwards-Oñoro, web designer and accessibility advocate</li>
       <li>Patrick Andrade, Assistive Technologist at The Chicago Lighthouse and Accessibility Advocate</li>
       <li>Soren Hamby, Senior Manager of UX and Digital Design at Benjamin Moore</li>
-      <li>Nathan Weber, Thomson Reuters, UX manager</li>
+      <li>Nathan Weber, Self</li>
       <li>Char James-Tanny, Accessibility Advocate</li>
       <li>Werner Rosenberger, MSc, CWAE, Certified WebAccessibility Expert, Projektleitung WACA - Web Accessibility Certificate Austria</li>
       <li>Riley MacIsaac, Quadriam, Design and Development Lead and Accessibility Specialist</li>
@@ -1086,7 +1086,7 @@
       <li>Andreas Jacobsen, CPWA, CEO, Inklud AS</li>
       <li>Kristian Munter Simonsen, CPWA, accessibility consultant, Inklud AS</li>
       <li>Jan McSorley, VP of Accessibility, Pearson Assessments</li>
-      <li>Caryn Pagel, Sr. Digital Accessibility Specialist, Thomson Reuters</li>
+      <li>Caryn Pagel, Self</li>
       <li>Rain Breaw Michaels, CPWA, Interaction Designer - Central Accessibility, Google</li>
       <li>Saptak Sengupta, Inclusive Web Developer</li>
       <li>Kazuhiko Tsuchiya, web usability and accessibility expert</li>


### PR DESCRIPTION
Some employees of Thomson Reuters have signed this overlay fact sheet who are not authorized to speak on behalf of the company in making statements or endorsements. This request is to remove the company affiliation information from current and former employees and remove mention of the organization from the copy of the page.