### PR TITLE
1073 sort and count

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -75,6 +75,17 @@
         <a href="#statement-from-sponsors-and-signatories-to-this-fact-sheet">
           Statement from sponsors and signatories to this fact sheet
         </a>
+        <ul>
+          <li>
+            <a href="#signed-by">Signed by</a>
+          </li>
+          <li>
+            <a href="#list-of-signatories">List of signatories</a>
+          </li>
+          <li>
+            <a href="#add-your-name">Add your name to the list</a>
+          </li>
+        </ul>
       </li>
       <li><a href="#additional-reading">Additional Reading</a></li>
     </ol>
@@ -509,7 +520,7 @@
       <p class="summary">Some overlay vendors have attempted to frame the overlay factsheet as an effort by their competitors to discredit them.
       Such overlay claims are a textbook case of an attempt to <a href="https://en.wikipedia.org/wiki/Gaslighting">gaslight</a> people to deflect criticism.</p>
 
-      <p>As of today, the <span id="total-count"></span> signatories to the overlay factsheet include:</p>
+      <p>As of today, the signatories to the overlay factsheet include:</p>
       <ul>
         <li>Contributors and editors for <abbr title="Web Content Accessibility Guidelines">WCAG</abbr>, <abbr title="Accessible Rich Internet Applications">ARIA</abbr>,
           and <abbr title="Hypertext Markup Language">HTML</abbr> specifications</li>
@@ -526,7 +537,11 @@
       <p>In short, the list of signatories below are people who are experts in this field &amp; have dedicated their professional careers to the
         improvement of accessibility or are end users with disabilities (or both). Discounting the names listed below as &quot;competitors&quot; is both inaccurate and
         misses the point: overlays are not an effective means of ensuring accessibility - a point on which all of the people below agree.</p>
-        <button id="sort-button">Sort List Alphabetically</button>
+               
+       <h3 id="list-of-signatories">List of signatories</h3>
+       <p>As of today, <span id="total-count"></span> supporters have signed this fact sheet.</p>
+        <button id="sort-button" class="add-your-name">Sort List Alphabetically</button>
+        <button id="reset-button" class="add-your-name">Reset List</button>
     <!--//
       Add your name to this list in accordance with the guidance provided in the repository's README document
     //-->
@@ -1344,7 +1359,8 @@
       <li>Matt Litzinger, Web Accessibility Specialist, Litz Digital</li>
       <li>Theodor Vararu, Software Engineer</li>
     </ol>
-    <p>
+    <h3 id="add-your-name"> Join the list:</h3>
+    <p>Add your name to the list by following the instruction published in our public repository on github.<p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">
         Add your name to this list
       </a>
@@ -1511,19 +1527,28 @@
   </div>
 </aside>
 <script>
-  var list = document.querySelector('#signatories');
-  var items = Array.from(list.getElementsByTagName('li'));
-  var button = document.getElementById('sort-button');
+    var list = document.querySelector('#signatories');
+    var items = Array.from(list.getElementsByTagName('li'));
+    var buttonSort = document.getElementById('sort-button');
+    var buttonReset = document.getElementById('reset-button');
 
-  document.getElementById('total-count').textContent = "Total count: " + items.length;
+    var originalOrder = items.slice();
 
-  button.addEventListener('click', function() {
-    items.sort(function(a, b) {
-      return a.textContent.localeCompare(b.textContent);
-    }).forEach(function(li) {
-      list.appendChild(li);
+    document.getElementById('total-count').textContent = items.length;
+
+    buttonSort.addEventListener('click', function() {
+      items.sort(function(a, b) {
+        return a.textContent.localeCompare(b.textContent);
+      }).forEach(function(li) {
+        list.appendChild(li);
+      });
     });
-  });
-</script>
+
+    buttonReset.addEventListener('click', function() {
+      originalOrder.forEach(function(li) {
+        list.appendChild(li);
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
I am proposing a few elements to improve the navigation and readability of the fact sheet:

1. **Table of contents** - Improved navigation for keyboard-only users by adding the three headings in the Table of Contents:

   - Signed by
   - List of signatories
   - Add your name to the list

2. **List of signatories** - Added a heading for the "List of signatories" to improve wayfinding and navigation
3. **Total Count** - Added a script to count total number of list items for signatories.  
4. **Sort List** - As the list continue to grow, being able to sort the list alphabetically provides a better navigation for screen reader users while enhancing the readability for all users
5. **Reset list** - just in case users want to see the order of which the list was signed.
6. **Join the list** - Created a heading to improve wayfinding and navigation, along with a brief description to inform users about the expected action.