### PR TITLE
Added Level Access

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -108,6 +108,7 @@
       <li>Equally.ai</li>
       <li>EqualWeb</li>
       <li>FACIL'iti</li>
+      <li>Level Access</li>
       <li>Lisio</li>
       <li>MaxAccess</li>
       <li>MK-Sense</li>


### PR DESCRIPTION
Level Access is now (or will be in 2024) an overlay vendor:
* https://www.levelaccess.com/news/level-access-agrees-to-acquire-userway/
* https://www.businesswire.com/news/home/20231230607997/en/UserWay-Agrees-to-be-Acquired-by-Digital-Accessibility-Leader-Level-Access