### PR TITLE
Level Access agrees to acquire UserWay

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -108,6 +108,7 @@
       <li>Equally.ai</li>
       <li>EqualWeb</li>
       <li>FACIL'iti</li>
+      <li>Level Access (has acquired UserWay)</li>
       <li>Lisio</li>
       <li>MaxAccess</li>
       <li>MK-Sense</li>


### PR DESCRIPTION
"When you buy an overlay company, you become an overlay company."

https://www.businesswire.com/news/home/20231230727471/en/Level-Access-Agrees-to-Acquire-UserWay