### PR TITLE
Fix of tag closure errors (W3C validator) 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1501,9 +1501,9 @@
       <li><a href="https://www.nbcnews.com/tech/innovation/blind-people-advocates-slam-company-claiming-make-websites-ada-compliant-n1266720">
         Blind people, advocates slam company claiming to make websites ADA compliant</a> <span class="further-reading-source">NBC News</span></li>
       <li><a href="https://www.forbes.com/sites/gusalexiou/2021/06/26/largest-us-blind-advocacy-group-bans-web-accessibility-overlay-giant-accessibe/?sh=6057fc125a15">
-        Largest U.S. Blind Advocacy Group Bans Web Accessibility Overlay Giant AccessiBe</a> <span class="further-reading-source">Forbes Magazine</span</li>
-        <li><a href="https://tink.uk/accessibe-and-data-protection/">AccessiBe and data protection?</a> <span class="further-reading-source">Léonie Watson</a></li>
-      <li><a href="https://www.lflegal.com/2021/11/overlay-legal-update/">Legal Update: Accessibility Overlay Edition</a> <span class="further-reading-source">Lainey Feingold</a></li>
+        Largest U.S. Blind Advocacy Group Bans Web Accessibility Overlay Giant AccessiBe</a> <span class="further-reading-source">Forbes Magazine</span></li>
+        <li><a href="https://tink.uk/accessibe-and-data-protection/">AccessiBe and data protection?</a> <span class="further-reading-source">Léonie Watson</span></li>
+      <li><a href="https://www.lflegal.com/2021/11/overlay-legal-update/">Legal Update: Accessibility Overlay Edition</a> <span class="further-reading-source">Lainey Feingold</span></li>
       <li><a href="https://overlayfalseclaims.com/">Truth in advertising does not exist for overlay vendors: False claims at the expense of customers and persons with disabilities.<span class="further-reading-source">Karl Groves and Michael Beck</span> </a> </li>
       <li>
         <a href="https://accessibleweb.com/web-accessibility-news/do-away-with-overlays/">Do Away with Overlays</a>


### PR DESCRIPTION
Some minor issues during W3C validation of the page due to some HTML tags not properly closed : 
![Capture d’écran 2024-02-13 à 13 53 04](https://github.com/karlgroves/overlayfactsheet/assets/6248074/eaee9dee-6853-4ae1-a2d8-82af49bb9854)
