### PR TITLE
Remove Lisio and Mk-sense

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -110,9 +110,7 @@
       <li>Equally.ai</li>
       <li>EqualWeb</li>
       <li>FACIL'iti</li>
-      <li>Lisio</li>
       <li>MaxAccess</li>
-      <li>MK-Sense</li>
       <li>Poloda AI</li>
       <li>Purple Lens</li>
       <li>ReciteME</li>


### PR DESCRIPTION
Lisio could not be found or is a different company now. Mk-sense/ make sense seems to have been absorbed by Allyable (somewhere in that history, those companies/ products and EqualWeb appear to have some sort of shared technology relationship)