### PR TITLE
Update listing Rian Rietveld

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -369,7 +369,7 @@
         Swarthmore College, Philadelphia
       </li>
       <li>Nicolas Steenhout, Independent accessibility consultant</li>
-      <li>Rian Rietveld, web accessibility specialist, Level Level</li>
+      <li>Rian Rietveld, web accessibility specialist</li>
       <li>Weston Thayer, Founder, Assistiv Labs</li>
       <li>Denis Boudreau, Accessibility consultant</li>
       <li>Meryl K. Evans, accessibility advocate</li>


### PR DESCRIPTION
This PR removes the company Level Level from the job description of Rian Rietveld, as she is now self employed.