### PR TITLE
Transition link underline along with background color

### DIFF
--- a/static/screen.css
+++ b/static/screen.css
@@ -148,15 +148,17 @@ blockquote {
 
 a {
   color: var(--color-red-700);
+  text-decoration-color: currentColor;
   transition:
   150ms background-color ease-in-out,
-  150ms color ease-in-out;
+  150ms color ease-in-out,
+  150ms text-decoration-color ease-in-out;
 }
 
 a:hover,
 a:focus {
   background-color: var(--color-red-100);
-  text-decoration: none;
+  text-decoration-color: transparent;
 }
 
 


### PR DESCRIPTION
I get super distracted by the links when the underline pops in and out of existance, especially because the text and background colors are set to ease in and out.

We cannot transition the existance of `text-decoration`, but we can transition its colour. So this PR simply sets it to transition the colour between the current text colour and transparent.