### PR TITLE
Add Marian Avery to list of endorsers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1415,6 +1415,7 @@
       <li>Josh Simpson, DeafBlind Accessibility Engineer</li>
       <li>Ariana Smith, CPACC, Co-Founder of A-11-Y and Digital Accessibility Professional</li>
       <li>Ashi Franke, Accessibility Manager & Section 508 Trusted Tester</li>
+      <li>Marian Avery, Content Accessibility Specialist at Content Design Ireland</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">


### PR DESCRIPTION
Adds Marian Avery, Content Accessibility Specialist at Content Design Ireland, to the "Signed by" endorsement list.

Follows the established format (`Name, Title at Organization`) with no link, per the endorsement guidelines in CLAUDE.md.