### PR TITLE
Make CI actually build the site

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,36 +1,87 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
+# Build the site on every change that targets an integration branch, so a broken
+# template or malformed edit is caught here rather than on the Netlify deploy.
 on:
-  # Triggers the workflow on push or pull request events but only for the develop branch
   push:
-    branches: [ develop ]
+    branches: [develop, main]
   pull_request:
-    branches: [ develop ]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: [develop, main]
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# Least privilege: this workflow only reads the repo.
+permissions:
+  contents: read
+
+# A newer push to the same branch/PR makes the in-flight run obsolete.
+# Cancelling it keeps Actions minutes down.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    name: Hugo build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+      # netlify.toml is the single source of truth for the Hugo version.
+      # Reading it here keeps CI and production from drifting apart — a build
+      # that passes on a different Hugo version proves nothing about the deploy.
+      - name: Resolve Hugo version from netlify.toml
+        id: hugo
         run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          version="$(grep -m1 -E '^[[:space:]]*HUGO_VERSION' netlify.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [ -z "$version" ]; then
+            echo "::error file=netlify.toml::Could not read HUGO_VERSION from netlify.toml"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building with Hugo $version (from netlify.toml)"
+
+      # 'extended' is intentionally off: the site ships plain CSS in static/ and
+      # has no SCSS/SASS, matching how Netlify builds it. If SCSS is ever added,
+      # set extended: true here and in the Netlify config together.
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ steps.hugo.outputs.version }}
+
+      # Same command as netlify.toml's [build] command.
+      - name: Build
+        run: hugo --gc --minify
+
+      # Hugo can exit 0 while producing an empty or partial site, so assert the
+      # output actually exists for every configured language.
+      - name: Verify build output
+        shell: bash
+        run: |
+          fail=0
+
+          if [ ! -s public/index.html ]; then
+            echo "::error::public/index.html is missing or empty"
+            fail=1
+          fi
+
+          langs="$(grep -oE '^[[:space:]]*\[languages\.[A-Za-z-]+\]' config.toml \
+            | sed -E 's/.*\[languages\.(.*)\]/\1/')"
+
+          if [ -z "$langs" ]; then
+            echo "::error file=config.toml::No [languages.*] entries found in config.toml"
+            exit 1
+          fi
+
+          while read -r lang; do
+            page="public/$lang/index.html"
+            if [ -s "$page" ]; then
+              echo "ok  $page ($(wc -c < "$page") bytes)"
+            else
+              echo "::error file=config.toml::$page is missing or empty"
+              fail=1
+            fi
+          done <<< "$langs"
+
+          exit $fail


### PR DESCRIPTION
## Problem

`.github/workflows/main.yml` was still the unmodified GitHub Actions starter template. Its only two steps were:

```yaml
- name: Run a one-line script
  run: echo Hello, world!

- name: Run a multi-line script
  run: |
    echo Add other actions to build,
    echo test, and deploy your project.
```

It never built anything. Every green check on every PR in this repo was meaningless — which is worse than having no check, because a green tick reads as verification. A PR that broke the Hugo template would have passed CI and only failed at the Netlify deploy.

## What this does

Replaces it with the actual gate:

- **Builds the site** with `hugo --gc --minify` — the same command `netlify.toml` uses.
- **Reads `HUGO_VERSION` from `netlify.toml`** instead of hardcoding it. A build that passes on a different Hugo version proves nothing about the deploy, and a hardcoded version silently drifts the first time Netlify's is bumped.
- **Verifies the output exists** — `public/index.html` plus a page for every `[languages.*]` entry in `config.toml`. Hugo can exit 0 while emitting an empty or partial site, so a zero exit code alone isn't sufficient.
- **Also runs on PRs targeting `main`**, not just `develop`, so the production branch is gated too.
- Housekeeping: `actions/checkout` v2 → v4, least-privilege `permissions: contents: read`, a 10-minute job timeout, and `concurrency` cancellation so superseded runs stop consuming Actions minutes.

## Verification

Both shell steps were dry-run locally against the real repo:

- Version resolution reads `0.93.3` out of `netlify.toml`.
- Output verification passes on a good build, listing all 9 languages.

Both failure paths were checked too, since a check that cannot fail is the exact bug being fixed here:

| Negative test | Result |
|---|---|
| Delete `public/ja/index.html` | verification step exits **1** |
| Append a malformed Go template expression to `layouts/index.html` | `hugo` exits **1** |

Local dry-runs used Hugo 0.152.2 (what's installed here); CI will use the pinned 0.93.3. The run on this PR is the real confirmation.

`extended` is deliberately left off — the site ships plain CSS in `static/` with no SCSS, matching how Netlify builds it. There's a comment in the workflow noting to flip both together if SCSS is ever added.
