### PR TITLE
Fix invalid lang attribute on Japanese pages (jp -> ja)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ home = ['HTML']
     [languages.ja.params]
       languageName = '日本語'
       languageNameShort = 'ja'
-      languageCode = 'jp'
+      languageCode = 'ja'
   [languages.id]
     contentDir = 'i18n/id'
     weight = 5


### PR DESCRIPTION
## Problem

Japanese pages render `<html lang="jp">`. `jp` is not a valid ISO 639-1 language code — it's the ISO 3166 *country* code for Japan. The correct language code for Japanese is `ja`.

This is a **WCAG 2.1 SC 3.1.1 (Language of Page)** failure: assistive technology cannot resolve `jp` to a language, so screen readers will not switch to a Japanese voice and will read the page with the user's default voice. Notable given the site is itself an accessibility resource.

## Root cause

In `config.toml`, the `[languages.ja.params]` block set `languageCode = 'jp'` while every other language sets a valid code. `layouts/index.html:2` emits it via `<html lang="{{ .Site.Params.languageCode }}">`.

## Fix

One character: `languageCode = 'jp'` → `languageCode = 'ja'`.

The same param is also used at `layouts/index.html:47` for the `lang` attribute on the language-switcher links, so this corrects both the page language and the switcher link language.

## Audit of the other eight languages

Checked every `languageCode` against its `[languages.X]` key:

| Key | `languageCode` | Status |
|---|---|---|
| en | `en` | OK |
| fr | `fr` | OK |
| pt-br | `pt-br` | OK — valid BCP 47 (`pt-BR`); tags are case-insensitive |
| **ja** | **`jp` → `ja`** | **Fixed** |
| id | `id` | OK |
| de | `de-de` | Valid — region-qualified rather than bare `de`, but a well-formed BCP 47 tag, so not a conformance failure. Left as-is to keep this PR to the actual bug. |
| nl | `nl` | OK |
| ro | `ro` | OK |
| es | `es` | OK |

No other drift found.

## Verification

`hugo --gc --minify` builds clean. Rendered `<html>` tags across all nine outputs:

```
public/de/index.html:<html lang=de-de
public/en/index.html:<html lang=en
public/es/index.html:<html lang=es
public/fr/index.html:<html lang=fr
public/id/index.html:<html lang=id
public/ja/index.html:<html lang=ja   <-- was lang=jp
public/nl/index.html:<html lang=nl
public/pt-br/index.html:<html lang=pt-br
public/ro/index.html:<html lang=ro
```

The language-switcher link pointing at Japanese also now carries `lang="ja"` (confirmed in `public/en/index.html`).