### PR TITLE
Add Sebastian Jansen as supporter

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1421,6 +1421,7 @@
       <li>Katrin Sellerbeck, Web Accessibility Consultant</li>
       <li>Kate Mitchell, Lead Accessibility Engineer, RemeDocs</li>
       <li>Hart Lorenzo Pableo, Full-Stack Web Developer, Freelance</li>
+      <li>Sebastian Jansen, Accessibility Consultant</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">


### PR DESCRIPTION
## What changed

Added Sebastian Jansen to the list of Overlay Fact Sheet supporters as a private individual.

## Entry

`Sebastian Jansen, Accessibility Consultant`

## Validation

Verified that the diff contains exactly one added line in `layouts/index.html` and no deletions.