### PR TITLE
Add Jake Quirke to the endorsement list

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1421,7 +1421,7 @@
       <li>Katrin Sellerbeck, Web Accessibility Consultant</li>
       <li>Kate Mitchell, Lead Accessibility Engineer, RemeDocs</li>
       <li>Hart Lorenzo Pableo, Full-Stack Web Developer, Freelance</li>
-      <li>Jake Quirke, CPACC, Frontend Software Engineer & Accessibility Lead at Giant Digital Ltd</li>
+      <li>Jake Quirke, CPACC, Software Engineer & Accessibility Lead at Giant Digital Ltd</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1415,6 +1415,7 @@
       <li>Josh Simpson, DeafBlind Accessibility Engineer</li>
       <li>Ariana Smith, CPACC, Co-Founder of A-11-Y and Digital Accessibility Professional</li>
       <li>Ashi Franke, Accessibility Manager & Section 508 Trusted Tester</li>
+      <li>Jake Quirke, Frontend Software Engineer & Accessibility Lead at Giant Digital Ltd</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1421,6 +1421,7 @@
       <li>Katrin Sellerbeck, Web Accessibility Consultant</li>
       <li>Kate Mitchell, Lead Accessibility Engineer, RemeDocs</li>
       <li>Hart Lorenzo Pableo, Full-Stack Web Developer, Freelance</li>
+      <li>Jake Quirke, Frontend Software Engineer & Accessibility Lead at Giant Digital Ltd</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1421,7 +1421,7 @@
       <li>Katrin Sellerbeck, Web Accessibility Consultant</li>
       <li>Kate Mitchell, Lead Accessibility Engineer, RemeDocs</li>
       <li>Hart Lorenzo Pableo, Full-Stack Web Developer, Freelance</li>
-      <li>Jake Quirke, Frontend Software Engineer & Accessibility Lead at Giant Digital Ltd</li>
+      <li>Jake Quirke, CPACC, Frontend Software Engineer & Accessibility Lead at Giant Digital Ltd</li>
     </ol>
     <p>
       <a class="add-your-name" href="https://github.com/karlgroves/overlayfactsheet/#endorse-this-statement">


### PR DESCRIPTION
Adds my endorsement signature to the "Signed by" list in `layouts/index.html`.

Format follows the contributing guidance in the README (Name, Title, Organization; no links):

`Jake Quirke, Frontend Software Engineer & Accessibility Lead at Giant Digital Ltd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)